### PR TITLE
feat: add admin user management page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,9 +4,11 @@ import Inventario from "./pages/Inventario";
 import Stock from "./pages/Stock";
 import Catalogo from "./pages/Catalogo";
 import Ventas from "./pages/Ventas";
+import UserManagement from "./pages/UserManagement";
 
 function App() {
   const [pagina, setPagina] = useState("inicio");
+  const [userRole] = useState(localStorage.getItem("role") || "Usuario");
 
   return (
     <div style={{ padding: 20 }}>
@@ -27,6 +29,11 @@ function App() {
         💵 Ventas/Encargos
       </button>
         <button onClick={() => setPagina("catalogo")} style={botonEstilo}>🛒 Catálogo de Productos</button>
+        {userRole === "Admin" && (
+          <button onClick={() => setPagina("usuarios")} style={botonEstilo}>
+            👥 Usuarios
+          </button>
+        )}
       </div>
 
       {/* Contenido dinámico según la opción */}
@@ -35,6 +42,7 @@ function App() {
       {pagina === "stock" && <Stock />}
       {pagina === "catalogo" && <Catalogo />}
       {pagina === "ventas" && <Ventas />}
+      {pagina === "usuarios" && userRole === "Admin" && <UserManagement />}
     </div>
   );
 }

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -1,0 +1,121 @@
+// 📄 src/pages/UserManagement.jsx
+import React, { useEffect, useState } from "react";
+import {
+  collection,
+  doc,
+  onSnapshot,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+} from "firebase/firestore";
+import { db } from "../firebase/firebaseConfig";
+
+const UserManagement = () => {
+  const [users, setUsers] = useState([]);
+  const [newUser, setNewUser] = useState({ name: "", role: "Usuario" });
+  const role = localStorage.getItem("role") || "Usuario";
+
+  useEffect(() => {
+    const q = collection(db, "users");
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const usuarios = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+      setUsers(usuarios);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const handleCreateUser = async (e) => {
+    e.preventDefault();
+    if (!newUser.name.trim()) return;
+    const ref = doc(collection(db, "users"));
+    await setDoc(ref, { name: newUser.name, role: newUser.role });
+    setNewUser({ name: "", role: "Usuario" });
+  };
+
+  const handleRoleChange = async (id, role) => {
+    await updateDoc(doc(db, "users", id), { role });
+  };
+
+  const handleDelete = async (id) => {
+    await deleteDoc(doc(db, "users", id));
+  };
+
+  if (role !== "Admin") {
+    return <div style={{ padding: 20 }}>Acceso restringido</div>;
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>👥 Gestión de Usuarios</h2>
+
+      <form onSubmit={handleCreateUser} style={{ marginBottom: 20 }}>
+        <input
+          type="text"
+          value={newUser.name}
+          onChange={(e) => setNewUser({ ...newUser, name: e.target.value })}
+          placeholder="Nombre"
+          style={{ marginRight: 10, padding: 5 }}
+        />
+        <select
+          value={newUser.role}
+          onChange={(e) => setNewUser({ ...newUser, role: e.target.value })}
+          style={{ marginRight: 10, padding: 5 }}
+        >
+          <option value="Usuario">Usuario</option>
+          <option value="Admin">Admin</option>
+        </select>
+        <button type="submit" style={{ padding: "5px 10px" }}>
+          ➕ Crear Usuario
+        </button>
+      </form>
+
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>
+              Nombre
+            </th>
+            <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>
+              Rol
+            </th>
+            <th style={{ borderBottom: "1px solid #ccc" }}>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((user) => (
+            <tr key={user.id}>
+              <td style={{ padding: "8px 0" }}>{user.name}</td>
+              <td>
+                <select
+                  value={user.role}
+                  onChange={(e) => handleRoleChange(user.id, e.target.value)}
+                  style={{ padding: 5 }}
+                >
+                  <option value="Usuario">Usuario</option>
+                  <option value="Admin">Admin</option>
+                </select>
+              </td>
+              <td>
+                <button
+                  onClick={() => handleDelete(user.id)}
+                  style={{
+                    color: "white",
+                    backgroundColor: "red",
+                    padding: "5px 10px",
+                    border: "none",
+                    borderRadius: 4,
+                    cursor: "pointer",
+                  }}
+                >
+                  Eliminar
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default UserManagement;


### PR DESCRIPTION
## Resumen
- Añadir página de administración de usuarios solo para administradores con soporte de Firestore
- Mostrar la sección "Usuarios" en la navegación para el rol de administrador

## Pruebas
- `npm run lint` *(error: no hay variables sin usar en los componentes existentes)*