### PR TITLE
feat: add user management page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import Inventario from "./pages/Inventario";
 import Stock from "./pages/Stock";
 import Catalogo from "./pages/Catalogo";
 import Ventas from "./pages/Ventas";
-import UserManagement from "./pages/UserManagement";
+import Users from "./pages/Users";
 
 function App() {
   const [pagina, setPagina] = useState("inicio");
@@ -53,7 +53,7 @@ function App() {
         </button>
         {role === "Admin" && (
           <button onClick={() => setPagina("usuarios")} style={botonEstilo}>
-            👥 Usuarios
+            👥 Gestión de Usuarios
           </button>
         )}
       </div>
@@ -64,7 +64,7 @@ function App() {
       {pagina === "stock" && <Stock />}
       {pagina === "catalogo" && <Catalogo />}
       {pagina === "ventas" && <Ventas role={role} />}
-      {pagina === "usuarios" && role === "Admin" && <UserManagement />}
+      {pagina === "usuarios" && role === "Admin" && <Users />}
     </div>
   );
 }

--- a/src/components/UserForm.jsx
+++ b/src/components/UserForm.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+
+const UserForm = ({ onCreate }) => {
+  const [newUser, setNewUser] = useState({ name: "", role: "Usuario" });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!newUser.name.trim()) return;
+    onCreate(newUser);
+    setNewUser({ name: "", role: "Usuario" });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ marginBottom: 20 }}>
+      <input
+        type="text"
+        value={newUser.name}
+        onChange={(e) => setNewUser({ ...newUser, name: e.target.value })}
+        placeholder="Nombre"
+        style={{ marginRight: 10, padding: 5 }}
+      />
+      <select
+        value={newUser.role}
+        onChange={(e) => setNewUser({ ...newUser, role: e.target.value })}
+        style={{ marginRight: 10, padding: 5 }}
+      >
+        <option value="Usuario">Usuario</option>
+        <option value="Admin">Admin</option>
+      </select>
+      <button type="submit" style={{ padding: "5px 10px" }}>
+        ➕ Crear Usuario
+      </button>
+    </form>
+  );
+};
+
+export default UserForm;
+

--- a/src/components/UserList.jsx
+++ b/src/components/UserList.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+const UserList = ({ users, onRoleChange, onDelete }) => (
+  <table style={{ width: "100%", borderCollapse: "collapse" }}>
+    <thead>
+      <tr>
+        <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>
+          Nombre
+        </th>
+        <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>
+          Rol
+        </th>
+        <th style={{ borderBottom: "1px solid #ccc" }}>Acciones</th>
+      </tr>
+    </thead>
+    <tbody>
+      {users.map((user) => (
+        <tr key={user.id}>
+          <td style={{ padding: "8px 0" }}>{user.name}</td>
+          <td>
+            <select
+              value={user.role}
+              onChange={(e) => onRoleChange(user.id, e.target.value)}
+              style={{ padding: 5 }}
+            >
+              <option value="Usuario">Usuario</option>
+              <option value="Admin">Admin</option>
+            </select>
+          </td>
+          <td>
+            <button
+              onClick={() => onDelete(user.id)}
+              style={{
+                color: "white",
+                backgroundColor: "red",
+                padding: "5px 10px",
+                border: "none",
+                borderRadius: 4,
+                cursor: "pointer",
+              }}
+            >
+              Eliminar
+            </button>
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+export default UserList;
+

--- a/src/pages/Users.jsx
+++ b/src/pages/Users.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import {
+  collection,
+  doc,
+  onSnapshot,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+} from "firebase/firestore";
+import { db } from "../firebase/firebaseConfig";
+import UserForm from "../components/UserForm";
+import UserList from "../components/UserList";
+
+const Users = () => {
+  const [users, setUsers] = useState([]);
+  const role = localStorage.getItem("role") || "Usuario";
+
+  useEffect(() => {
+    const q = collection(db, "users");
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const usuarios = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+      setUsers(usuarios);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const handleCreateUser = async (user) => {
+    const ref = doc(collection(db, "users"));
+    await setDoc(ref, user);
+  };
+
+  const handleRoleChange = async (id, newRole) => {
+    await updateDoc(doc(db, "users", id), { role: newRole });
+  };
+
+  const handleDelete = async (id) => {
+    await deleteDoc(doc(db, "users", id));
+  };
+
+  if (role !== "Admin") {
+    return <div style={{ padding: 20 }}>Acceso restringido</div>;
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>👥 Gestión de Usuarios</h2>
+      <UserForm onCreate={handleCreateUser} />
+      <UserList users={users} onRoleChange={handleRoleChange} onDelete={handleDelete} />
+    </div>
+  );
+};
+
+export default Users;
+


### PR DESCRIPTION
## Summary
- add users page wired to Firestore users collection
- allow admins to change roles and remove users
- show new 'Gestión de Usuarios' menu item for admins only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6893bc8cb098832197c43b179a3ce900