### PR TITLE
feat: add auth login and fallback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,12 +5,19 @@ import Stock from "./pages/Stock";
 import Catalogo from "./pages/Catalogo";
 import Ventas from "./pages/Ventas";
 import UserManagement from "./pages/UserManagement";
+import Login from "./pages/Login.jsx";
+import { useAuth } from "./contexts/AuthContext.jsx";
 
 function App() {
+  const { user } = useAuth();
   const [pagina, setPagina] = useState("inicio");
   const [role, setRole] = useState(
     () => localStorage.getItem("role") || "Admin"
   );
+
+  if (!user) {
+    return <Login />;
+  }
 
   const handleChangeRole = (e) => {
     const newRole = e.target.value;

--- a/src/components/InventarioForm.jsx
+++ b/src/components/InventarioForm.jsx
@@ -56,10 +56,9 @@ const InventarioForm = ({ onAgregar, productoEscaneado }) => {
       return;
     }
 
-    const total = parseInt(precio) * parseInt(cantidad);
-   // const fecha = new Date().toLocaleDateString("es-CO");
-   // const hora = new Date().toLocaleTimeString("es-CO");
-
+      // const total = parseInt(precio) * parseInt(cantidad);
+      // const fecha = new Date().toLocaleDateString("es-CO");
+      // const hora = new Date().toLocaleTimeString("es-CO");
 
     const productoFinal = {
       ...producto,

--- a/src/components/VentasForm.jsx
+++ b/src/components/VentasForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { collection, getDocs, query } from "firebase/firestore";
+import { collection, getDocs } from "firebase/firestore";
 import { db } from "../firebase/firebaseConfig";
 
 const VentasForm = ({ productoEscaneado, onAgregar, onAgregarEncargo }) => {
@@ -91,12 +91,12 @@ const VentasForm = ({ productoEscaneado, onAgregar, onAgregarEncargo }) => {
     }
   }, [productoEscaneado]);
 
-  const calcularTotalesCarrito = () => {
-    const total = carrito.reduce((sum, item) => sum + (item.total || 0), 0);
-    const abono = carrito.reduce((sum, item) => sum + (item.abono || 0), 0);
-    const saldo = total - abono;
-    return { total, abono, saldo };
-  };
+    // const calcularTotalesCarrito = () => {
+    //   const total = carrito.reduce((sum, item) => sum + (item.total || 0), 0);
+    //   const abono = carrito.reduce((sum, item) => sum + (item.abono || 0), 0);
+    //   const saldo = total - abono;
+    //   return { total, abono, saldo };
+    // };
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -209,8 +209,8 @@ const VentasForm = ({ productoEscaneado, onAgregar, onAgregarEncargo }) => {
   };
 
   // === FUNCION PARA REGISTRAR EL ENCARGO ===
-  const limpiarObjeto = (obj) =>
-    Object.fromEntries(Object.entries(obj).filter(([_, v]) => v !== undefined));
+    // const limpiarObjeto = (obj) =>
+    //   Object.fromEntries(Object.entries(obj).filter(([_, v]) => v !== undefined));
 
   // Registrar el encargo correctamente
   const registrarEncargo = async () => {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,6 +1,13 @@
 /* eslint react-refresh/only-export-components: "off" */
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { getAuth, onAuthStateChanged } from "firebase/auth";
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  GoogleAuthProvider,
+  signInWithPopup,
+  signOut,
+} from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 import { db } from "../firebase/firebaseConfig";
 
@@ -30,8 +37,18 @@ export const AuthProvider = ({ children }) => {
     return () => unsubscribe();
   }, [auth]);
 
+  const login = (email, password) =>
+    signInWithEmailAndPassword(auth, email, password);
+
+  const loginWithGoogle = () => {
+    const provider = new GoogleAuthProvider();
+    return signInWithPopup(auth, provider);
+  };
+
+  const logout = () => signOut(auth);
+
   return (
-    <AuthContext.Provider value={{ user, role }}>
+    <AuthContext.Provider value={{ user, role, login, loginWithGoogle, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Catalogo.jsx
+++ b/src/pages/Catalogo.jsx
@@ -79,12 +79,12 @@ const Catalogo = () => {
     setProductos(colegiosArray);
   };
 
-  const toggleExpandirProducto = (productoKey) => {
-    setProductosExpandidos((prev) => ({
-      ...prev,
-      [productoKey]: !prev[productoKey],
-    }));
-  };
+    // const toggleExpandirProducto = (productoKey) => {
+    //   setProductosExpandidos((prev) => ({
+    //     ...prev,
+    //     [productoKey]: !prev[productoKey],
+    //   }));
+    // };
 
   const handleChange = (e) => {
     const { name, value } = e.target;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,47 +1,37 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  getAuth,
-  GoogleAuthProvider,
-  signInWithPopup,
-} from "../firebase/firebaseConfig";
-import { signInWithEmailAndPassword } from "firebase/auth";
+import { useAuth } from "../contexts/AuthContext.jsx";
 
 const Login = () => {
-  const auth = getAuth();
-  const navigate = useNavigate();
+  const { login, loginWithGoogle } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
 
-  const handleEmailLogin = async (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await signInWithEmailAndPassword(auth, email, password);
+      await login(email, password);
       navigate("/");
-    } catch (error) {
-      console.error("Error al iniciar sesión:", error);
-      setErrorMessage("No se pudo iniciar sesión. Verifica tus credenciales.");
+    } catch {
+      setError("No se pudo iniciar sesión. Verifica tus credenciales.");
     }
   };
 
-  const handleGoogleLogin = async () => {
+  const handleGoogle = async () => {
     try {
-      const provider = new GoogleAuthProvider();
-      await signInWithPopup(auth, provider);
+      await loginWithGoogle();
       navigate("/");
-    } catch (error) {
-      console.error("Error al iniciar sesión con Google:", error);
-      setErrorMessage(
-        "Error al iniciar sesión con Google. Verifica la configuración de Firebase.",
-      );
+    } catch {
+      setError("Error al iniciar sesión con Google.");
     }
   };
 
   return (
     <div style={{ padding: 20 }}>
       <h2>Iniciar Sesión</h2>
-      <form onSubmit={handleEmailLogin} style={{ marginBottom: 20 }}>
+      <form onSubmit={handleSubmit} style={{ marginBottom: 20 }}>
         <div>
           <input
             type="email"
@@ -60,10 +50,8 @@ const Login = () => {
         </div>
         <button type="submit">Ingresar</button>
       </form>
-      <button onClick={handleGoogleLogin}>Ingresar con Google</button>
-      {errorMessage && (
-        <p style={{ color: "red", marginTop: 20 }}>{errorMessage}</p>
-      )}
+      <button onClick={handleGoogle}>Continuar con Google</button>
+      {error && <p style={{ color: "red", marginTop: 20 }}>{error}</p>}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add auth helper methods for email/password and Google login
- show login screen when user isn't authenticated
- clean up unused variables for successful linting

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893bc90b8448321be1fa2e8009b2319