### PR TITLE
feat: secure routing with roles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,70 +1,87 @@
-import React, { useState } from "react";
+import React from "react";
+import { Link, Routes, Route } from "react-router-dom";
 import Inicio from "./pages/Inicio";
 import Inventario from "./pages/Inventario";
 import Stock from "./pages/Stock";
 import Catalogo from "./pages/Catalogo";
 import Ventas from "./pages/Ventas";
 import UserManagement from "./pages/UserManagement";
+import { useAuth } from "./contexts/AuthContext.jsx";
+import RoleRoute from "./components/RoleRoute.jsx";
 
 function App() {
-  const [pagina, setPagina] = useState("inicio");
-  const [role, setRole] = useState(
-    () => localStorage.getItem("role") || "Admin"
-  );
-
-  const handleChangeRole = (e) => {
-    const newRole = e.target.value;
-    setRole(newRole);
-    localStorage.setItem("role", newRole);
-  };
+  const { role } = useAuth();
 
   return (
     <div style={{ padding: 20 }}>
       <h1>🧵 Steven Todo en Uniformes</h1>
 
-      <div style={{ marginBottom: 20 }}>
-        <label htmlFor="rol" style={{ marginRight: 10 }}>
-          Rol:
-        </label>
-        <select id="rol" value={role} onChange={handleChangeRole}>
-          <option value="Admin">Admin</option>
-          <option value="Vendedor">Vendedor</option>
-        </select>
-      </div>
-
-      {/* Menú superior */}
-      <div style={{ marginBottom: 30 }}>
-        <button onClick={() => setPagina("inicio")} style={botonEstilo}>
+      <nav style={{ marginBottom: 30 }}>
+        <Link to="/" style={botonEstilo}>
           🏠 Inicio
-        </button>
+        </Link>
         {role === "Admin" && (
-          <button onClick={() => setPagina("inventario")} style={botonEstilo}>
-            ➕ Agregar Inventario
-          </button>
+          <>
+            <Link to="/inventario" style={botonEstilo}>
+              ➕ Agregar Inventario
+            </Link>
+            <Link to="/stock" style={botonEstilo}>
+              📦 Ver Stock Actual
+            </Link>
+            <Link to="/ventas" style={botonEstilo}>
+              💵 Ventas/Encargos
+            </Link>
+            <Link to="/catalogo" style={botonEstilo}>
+              🛒 Catálogo de Productos
+            </Link>
+            <Link to="/usuarios" style={botonEstilo}>
+              👥 Usuarios
+            </Link>
+          </>
         )}
-        <button onClick={() => setPagina("stock")} style={botonEstilo}>
-          📦 Ver Stock Actual
-        </button>
-        <button onClick={() => setPagina("ventas")} style={botonEstilo}>
-          💵 Ventas/Encargos
-        </button>
-        <button onClick={() => setPagina("catalogo")} style={botonEstilo}>
-          🛒 Catálogo de Productos
-        </button>
-        {role === "Admin" && (
-          <button onClick={() => setPagina("usuarios")} style={botonEstilo}>
-            👥 Usuarios
-          </button>
+        {role === "Vendedor" && (
+          <Link to="/ventas" style={botonEstilo}>
+            💵 Ventas/Encargos
+          </Link>
         )}
-      </div>
+      </nav>
 
-      {/* Contenido dinámico según la opción */}
-      {pagina === "inicio" && <Inicio />}
-      {pagina === "inventario" && <Inventario role={role} />}
-      {pagina === "stock" && <Stock />}
-      {pagina === "catalogo" && <Catalogo />}
-      {pagina === "ventas" && <Ventas role={role} />}
-      {pagina === "usuarios" && role === "Admin" && <UserManagement />}
+      <Routes>
+        <Route path="/" element={<Inicio />} />
+        <Route
+          path="/inventario"
+          element={
+            <RoleRoute roles={["Admin"]}>
+              <Inventario />
+            </RoleRoute>
+          }
+        />
+        <Route
+          path="/stock"
+          element={
+            <RoleRoute roles={["Admin"]}>
+              <Stock />
+            </RoleRoute>
+          }
+        />
+        <Route path="/ventas" element={<Ventas />} />
+        <Route
+          path="/catalogo"
+          element={
+            <RoleRoute roles={["Admin"]}>
+              <Catalogo />
+            </RoleRoute>
+          }
+        />
+        <Route
+          path="/usuarios"
+          element={
+            <RoleRoute roles={["Admin"]}>
+              <UserManagement />
+            </RoleRoute>
+          }
+        />
+      </Routes>
     </div>
   );
 }

--- a/src/components/InventarioForm.jsx
+++ b/src/components/InventarioForm.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import { collection, getDocs } from "firebase/firestore";
 import { db } from "../firebase/firebaseConfig";
+import { useAuth } from "../contexts/AuthContext.jsx";
 
 const InventarioForm = ({ onAgregar, productoEscaneado }) => {
   const [producto, setProducto] = useState({
@@ -46,29 +47,30 @@ const InventarioForm = ({ onAgregar, productoEscaneado }) => {
     const { name, value } = e.target;
     setProducto((prev) => ({ ...prev, [name]: value }));
   };
+  const { role } = useAuth();
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const { colegio, prenda, talla, precio, cantidad } = producto;
+
+    if (role !== "Admin") {
+      alert("Acceso restringido");
+      return;
+    }
 
     if (!colegio || !prenda || !talla || !precio || !cantidad) {
       alert("Completa todos los campos");
       return;
     }
 
-    const total = parseInt(precio) * parseInt(cantidad);
-   // const fecha = new Date().toLocaleDateString("es-CO");
-   // const hora = new Date().toLocaleTimeString("es-CO");
-
-
     const productoFinal = {
       ...producto,
       precio: parseInt(precio),
       cantidad: parseInt(cantidad),
     };
-    
-    onAgregar(productoFinal); 
-};
+
+    onAgregar(productoFinal);
+  };
 
 
   return (

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -1,0 +1,9 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext.jsx";
+
+const PrivateRoute = ({ children }) => {
+  const { user } = useAuth();
+  return user ? children : <Navigate to="/login" replace />;
+};
+
+export default PrivateRoute;

--- a/src/components/RoleRoute.jsx
+++ b/src/components/RoleRoute.jsx
@@ -1,0 +1,11 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext.jsx";
+
+const RoleRoute = ({ roles, children }) => {
+  const { role } = useAuth();
+
+  if (role === null) return null;
+  return roles.includes(role) ? children : <Navigate to="/" replace />;
+};
+
+export default RoleRoute;

--- a/src/components/VentasForm.jsx
+++ b/src/components/VentasForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { collection, getDocs, query } from "firebase/firestore";
+import { collection, getDocs } from "firebase/firestore";
 import { db } from "../firebase/firebaseConfig";
 
 const VentasForm = ({ productoEscaneado, onAgregar, onAgregarEncargo }) => {
@@ -91,12 +91,6 @@ const VentasForm = ({ productoEscaneado, onAgregar, onAgregarEncargo }) => {
     }
   }, [productoEscaneado]);
 
-  const calcularTotalesCarrito = () => {
-    const total = carrito.reduce((sum, item) => sum + (item.total || 0), 0);
-    const abono = carrito.reduce((sum, item) => sum + (item.abono || 0), 0);
-    const saldo = total - abono;
-    return { total, abono, saldo };
-  };
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -207,10 +201,6 @@ const VentasForm = ({ productoEscaneado, onAgregar, onAgregarEncargo }) => {
     const exito = await onAgregar(carrito);
     if (exito) setCarrito([]);
   };
-
-  // === FUNCION PARA REGISTRAR EL ENCARGO ===
-  const limpiarObjeto = (obj) =>
-    Object.fromEntries(Object.entries(obj).filter(([_, v]) => v !== undefined));
 
   // Registrar el encargo correctamente
   const registrarEncargo = async () => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,16 +1,12 @@
 /* eslint react-refresh/only-export-components: "off" */
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 import Login from './pages/Login.jsx'
-import { AuthProvider, useAuth } from './contexts/AuthContext.jsx'
-
-function PrivateRoute({ children }) {
-  const { user } = useAuth()
-  return user ? children : <Navigate to="/login" />
-}
+import { AuthProvider } from './contexts/AuthContext.jsx'
+import PrivateRoute from './components/PrivateRoute.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/pages/Catalogo.jsx
+++ b/src/pages/Catalogo.jsx
@@ -79,12 +79,6 @@ const Catalogo = () => {
     setProductos(colegiosArray);
   };
 
-  const toggleExpandirProducto = (productoKey) => {
-    setProductosExpandidos((prev) => ({
-      ...prev,
-      [productoKey]: !prev[productoKey],
-    }));
-  };
 
   const handleChange = (e) => {
     const { name, value } = e.target;

--- a/src/pages/Inventario.jsx
+++ b/src/pages/Inventario.jsx
@@ -15,11 +15,13 @@ import { db } from "../firebase/firebaseConfig";
 import InventarioForm from "../components/InventarioForm";
 import InventarioTable from "../components/InventarioTable";
 import Escaner from "../components/Escaner";
+import { useAuth } from "../contexts/AuthContext.jsx";
 
-const Inventario = ({ role }) => {
+const Inventario = () => {
   const [inventario, setInventario] = useState([]);
   const [mostrarEscaner, setMostrarEscaner] = useState(false);
   const [productoInicial, setProductoInicial] = useState(null);
+  const { role } = useAuth();
 
   const cargarInventario = async () => {
     const snap = await getDocs(collection(db, "inventario"));
@@ -53,6 +55,10 @@ const Inventario = ({ role }) => {
 
   // ✅ Agregar al inventario y también al stock_actual
   const handleAgregarInventario = async (productoFinal) => {
+    if (role !== "Admin") {
+      alert("Acceso restringido");
+      return;
+    }
     try {
       await addDoc(collection(db, "inventario"), {
         ...productoFinal,
@@ -93,6 +99,10 @@ const Inventario = ({ role }) => {
 
   // ✅ Eliminar de inventario y RESTAR del stock_actual
   const handleEliminar = async (id) => {
+    if (role !== "Admin") {
+      alert("Acceso restringido");
+      return;
+    }
     try {
       const docRef = doc(db, "inventario", id);
       const docSnap = await getDoc(docRef);

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -9,11 +9,12 @@ import {
   deleteDoc,
 } from "firebase/firestore";
 import { db } from "../firebase/firebaseConfig";
+import { useAuth } from "../contexts/AuthContext.jsx";
 
 const UserManagement = () => {
   const [users, setUsers] = useState([]);
   const [newUser, setNewUser] = useState({ name: "", role: "Usuario" });
-  const role = localStorage.getItem("role") || "Usuario";
+  const { role } = useAuth();
 
   useEffect(() => {
     const q = collection(db, "users");

--- a/src/pages/Ventas.jsx
+++ b/src/pages/Ventas.jsx
@@ -17,13 +17,15 @@ import VentasTable from "../components/VentasTable";
 import EncargosTable from "../components/EncargosTable";
 import Escaner from "../components/Escaner";
 import CardTable from "../components/CardTable"; // Ajusta la ruta si es necesario
+import { useAuth } from "../contexts/AuthContext.jsx";
 
-const Ventas = ({ role }) => {
+const Ventas = () => {
   const [ventas, setVentas] = useState([]);
   const [encargos, setEncargos] = useState([]);
   const [mostrarEscaner, setMostrarEscaner] = useState(false);
   const [productoEscaneado, setProductoEscaneado] = useState(null);
   const [tabActiva, setTabActiva] = useState("ventas");
+  const { role } = useAuth();
 
   // Cargar ventas y encargos al iniciar
   const cargarDatos = async () => {


### PR DESCRIPTION
## Summary
- replace state navigation with React Router and role-protected routes
- add PrivateRoute and RoleRoute components backed by AuthContext
- validate admin role before inventory mutations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893bc8d3060832194c5786d89be269d