### PR TITLE
feat: integrate Firestore user roles and permission helpers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useAuth } from "./contexts/AuthContext.jsx";
 import Inicio from "./pages/Inicio";
 import Inventario from "./pages/Inventario";
 import Stock from "./pages/Stock";
@@ -8,28 +9,14 @@ import UserManagement from "./pages/UserManagement";
 
 function App() {
   const [pagina, setPagina] = useState("inicio");
-  const [role, setRole] = useState(
-    () => localStorage.getItem("role") || "Admin"
-  );
-
-  const handleChangeRole = (e) => {
-    const newRole = e.target.value;
-    setRole(newRole);
-    localStorage.setItem("role", newRole);
-  };
+  const { role, hasRole } = useAuth();
 
   return (
     <div style={{ padding: 20 }}>
       <h1>🧵 Steven Todo en Uniformes</h1>
 
       <div style={{ marginBottom: 20 }}>
-        <label htmlFor="rol" style={{ marginRight: 10 }}>
-          Rol:
-        </label>
-        <select id="rol" value={role} onChange={handleChangeRole}>
-          <option value="Admin">Admin</option>
-          <option value="Vendedor">Vendedor</option>
-        </select>
+        <strong>Rol:</strong> {role || "sin asignar"}
       </div>
 
       {/* Menú superior */}
@@ -37,7 +24,7 @@ function App() {
         <button onClick={() => setPagina("inicio")} style={botonEstilo}>
           🏠 Inicio
         </button>
-        {role === "Admin" && (
+        {hasRole("admin") && (
           <button onClick={() => setPagina("inventario")} style={botonEstilo}>
             ➕ Agregar Inventario
           </button>
@@ -51,7 +38,7 @@ function App() {
         <button onClick={() => setPagina("catalogo")} style={botonEstilo}>
           🛒 Catálogo de Productos
         </button>
-        {role === "Admin" && (
+        {hasRole("admin") && (
           <button onClick={() => setPagina("usuarios")} style={botonEstilo}>
             👥 Usuarios
           </button>
@@ -60,11 +47,11 @@ function App() {
 
       {/* Contenido dinámico según la opción */}
       {pagina === "inicio" && <Inicio />}
-      {pagina === "inventario" && <Inventario role={role} />}
+      {pagina === "inventario" && <Inventario />}
       {pagina === "stock" && <Stock />}
       {pagina === "catalogo" && <Catalogo />}
-      {pagina === "ventas" && <Ventas role={role} />}
-      {pagina === "usuarios" && role === "Admin" && <UserManagement />}
+      {pagina === "ventas" && <Ventas />}
+      {pagina === "usuarios" && hasRole("admin") && <UserManagement />}
     </div>
   );
 }

--- a/src/components/EncargosTable.jsx
+++ b/src/components/EncargosTable.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
+import { useAuth } from "../contexts/AuthContext.jsx";
 
-const EncargosTable = ({ encargos, onActualizarEstado, role }) => {
+const EncargosTable = ({ encargos, onActualizarEstado }) => {
+  const { hasRole } = useAuth();
   const [encargoExpandido, setEncargoExpandido] = useState(null);
   const [mostrarHistorial, setMostrarHistorial] = useState(false);
 
@@ -83,7 +85,7 @@ const EncargosTable = ({ encargos, onActualizarEstado, role }) => {
               <th style={estiloEncabezado}>Fecha</th>
               <th style={estiloEncabezado}>Total</th>
               <th style={estiloEncabezado}>Estado</th>
-              {role === "Admin" && (
+              {hasRole("admin") && (
                 <th style={estiloEncabezado}>Acciones</th>
               )}
             </tr>
@@ -134,7 +136,7 @@ const EncargosTable = ({ encargos, onActualizarEstado, role }) => {
                       {encargo.estado}
                     </span>
                   </td>
-                  {role === "Admin" && (
+                  {hasRole("admin") && (
                     <td style={estiloCelda}>
                       {encargo.estado === "pendiente" && (
                         <>

--- a/src/components/InventarioTable.jsx
+++ b/src/components/InventarioTable.jsx
@@ -1,9 +1,11 @@
 // 📄 src/components/InventarioTable.jsx
 
 import React from "react";
+import { useAuth } from "../contexts/AuthContext.jsx";
 import CardTable from './CardTable'; // Ajusta la ruta
 
-const InventarioTable = ({ productos = [], onEliminar, role }) => {
+const InventarioTable = ({ productos = [], onEliminar }) => {
+  const { hasRole } = useAuth();
   const convertirFecha = (fechaHora) => {
     if (!fechaHora || !fechaHora.seconds) return "-";
     const date = new Date(fechaHora.seconds * 1000);
@@ -43,7 +45,7 @@ const InventarioTable = ({ productos = [], onEliminar, role }) => {
           <th>Vr. Total</th>
           <th>Fecha</th>
           <th>Hora</th>
-          {role === "Admin" && <th>Acciones</th>}
+          {hasRole("admin") && <th>Acciones</th>}
           </tr>
         </thead>
 <tbody>
@@ -69,7 +71,7 @@ const InventarioTable = ({ productos = [], onEliminar, role }) => {
           <td style={estiloCelda}>{total.toLocaleString("es-CO")}</td>
           <td style={estiloCelda}>{convertirFecha(p.fechaHora)}</td>
           <td style={estiloCelda}>{convertirHora(p.fechaHora)}</td>
-          {role === "Admin" && (
+          {hasRole("admin") && (
             <td style={estiloCelda}>
               <button
                 onClick={() => onEliminar(p.id)}

--- a/src/components/VentasTable.jsx
+++ b/src/components/VentasTable.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
+import { useAuth } from "../contexts/AuthContext.jsx";
 import CardTable from "./CardTable"; // Ajusta la ruta
 
-const VentasTable = ({ ventas, onActualizarEstado, totalVentas, role }) => {
+const VentasTable = ({ ventas, onActualizarEstado, totalVentas }) => {
+  const { hasRole } = useAuth();
   const [fechasExpandidas, setFechasExpandidas] = useState({});
 
   // Estilos
@@ -219,7 +221,7 @@ const VentasTable = ({ ventas, onActualizarEstado, totalVentas, role }) => {
                                 >
                                   {v.estado || "venta"}
                                 </span>
-                                  {v.estado === "separado" && role === "Admin" && (
+                                  {v.estado === "separado" && hasRole("admin") && (
                                     <button
                                       onClick={() => marcarComoPagado(v.id)}
                                       style={{

--- a/src/pages/Inventario.jsx
+++ b/src/pages/Inventario.jsx
@@ -1,5 +1,6 @@
 // 📄 src/pages/Inventario.jsx
 import React, { useEffect, useState } from "react";
+import { useAuth } from "../contexts/AuthContext.jsx";
 import {
   collection,
   getDocs,
@@ -16,7 +17,8 @@ import InventarioForm from "../components/InventarioForm";
 import InventarioTable from "../components/InventarioTable";
 import Escaner from "../components/Escaner";
 
-const Inventario = ({ role }) => {
+const Inventario = () => {
+  const { hasRole } = useAuth();
   const [inventario, setInventario] = useState([]);
   const [mostrarEscaner, setMostrarEscaner] = useState(false);
   const [productoInicial, setProductoInicial] = useState(null);
@@ -134,7 +136,7 @@ const Inventario = ({ role }) => {
     <div style={{ padding: 20 }}>
       <h2>📦 Agregar al Inventario</h2>
 
-      {role === "Admin" && (
+      {hasRole("admin") && (
         <>
           <button
             onClick={() => setMostrarEscaner((prev) => !prev)}
@@ -158,11 +160,7 @@ const Inventario = ({ role }) => {
         </>
       )}
 
-      <InventarioTable
-        productos={inventario}
-        onEliminar={handleEliminar}
-        role={role}
-      />
+      <InventarioTable productos={inventario} onEliminar={handleEliminar} />
     </div>
   );
 };

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -8,12 +8,13 @@ import {
   updateDoc,
   deleteDoc,
 } from "firebase/firestore";
+import { useAuth } from "../contexts/AuthContext.jsx";
 import { db } from "../firebase/firebaseConfig";
 
 const UserManagement = () => {
+  const { hasRole } = useAuth();
   const [users, setUsers] = useState([]);
-  const [newUser, setNewUser] = useState({ name: "", role: "Usuario" });
-  const role = localStorage.getItem("role") || "Usuario";
+  const [newUser, setNewUser] = useState({ uid: "", name: "", role: "vendedor" });
 
   useEffect(() => {
     const q = collection(db, "users");
@@ -26,10 +27,12 @@ const UserManagement = () => {
 
   const handleCreateUser = async (e) => {
     e.preventDefault();
-    if (!newUser.name.trim()) return;
-    const ref = doc(collection(db, "users"));
-    await setDoc(ref, { name: newUser.name, role: newUser.role });
-    setNewUser({ name: "", role: "Usuario" });
+    if (!newUser.uid.trim()) return;
+    await setDoc(doc(db, "users", newUser.uid), {
+      name: newUser.name,
+      role: newUser.role,
+    });
+    setNewUser({ uid: "", name: "", role: "vendedor" });
   };
 
   const handleRoleChange = async (id, role) => {
@@ -40,7 +43,7 @@ const UserManagement = () => {
     await deleteDoc(doc(db, "users", id));
   };
 
-  if (role !== "Admin") {
+  if (!hasRole("admin")) {
     return <div style={{ padding: 20 }}>Acceso restringido</div>;
   }
 
@@ -49,6 +52,13 @@ const UserManagement = () => {
       <h2>👥 Gestión de Usuarios</h2>
 
       <form onSubmit={handleCreateUser} style={{ marginBottom: 20 }}>
+        <input
+          type="text"
+          value={newUser.uid}
+          onChange={(e) => setNewUser({ ...newUser, uid: e.target.value })}
+          placeholder="UID"
+          style={{ marginRight: 10, padding: 5 }}
+        />
         <input
           type="text"
           value={newUser.name}
@@ -61,8 +71,8 @@ const UserManagement = () => {
           onChange={(e) => setNewUser({ ...newUser, role: e.target.value })}
           style={{ marginRight: 10, padding: 5 }}
         >
-          <option value="Usuario">Usuario</option>
-          <option value="Admin">Admin</option>
+          <option value="vendedor">vendedor</option>
+          <option value="admin">admin</option>
         </select>
         <button type="submit" style={{ padding: "5px 10px" }}>
           ➕ Crear Usuario
@@ -72,9 +82,8 @@ const UserManagement = () => {
       <table style={{ width: "100%", borderCollapse: "collapse" }}>
         <thead>
           <tr>
-            <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>
-              Nombre
-            </th>
+            <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>UID</th>
+            <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>Nombre</th>
             <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>
               Rol
             </th>
@@ -82,8 +91,9 @@ const UserManagement = () => {
           </tr>
         </thead>
         <tbody>
-          {users.map((user) => (
+            {users.map((user) => (
             <tr key={user.id}>
+              <td style={{ padding: "8px 0" }}>{user.id}</td>
               <td style={{ padding: "8px 0" }}>{user.name}</td>
               <td>
                 <select
@@ -91,8 +101,8 @@ const UserManagement = () => {
                   onChange={(e) => handleRoleChange(user.id, e.target.value)}
                   style={{ padding: 5 }}
                 >
-                  <option value="Usuario">Usuario</option>
-                  <option value="Admin">Admin</option>
+                  <option value="vendedor">vendedor</option>
+                  <option value="admin">admin</option>
                 </select>
               </td>
               <td>

--- a/src/pages/Ventas.jsx
+++ b/src/pages/Ventas.jsx
@@ -18,7 +18,7 @@ import EncargosTable from "../components/EncargosTable";
 import Escaner from "../components/Escaner";
 import CardTable from "../components/CardTable"; // Ajusta la ruta si es necesario
 
-const Ventas = ({ role }) => {
+const Ventas = () => {
   const [ventas, setVentas] = useState([]);
   const [encargos, setEncargos] = useState([]);
   const [mostrarEscaner, setMostrarEscaner] = useState(false);
@@ -260,7 +260,6 @@ const Ventas = ({ role }) => {
             onActualizarEstado={(id, estado) =>
               handleActualizarEstado(id, estado, "ventas")
             }
-            role={role}
           />
         </>
       ) : (
@@ -269,7 +268,6 @@ const Ventas = ({ role }) => {
           onActualizarEstado={(id, estado) =>
             handleActualizarEstado(id, estado, "encargos")
           }
-          role={role}
         />
       )}
     </div>


### PR DESCRIPTION
## Resumen
- Leer roles de usuario de una colección `users` de Firestore y exponer un asistente `hasRole` mediante `AuthContext`
- Usar comprobaciones basadas en roles en el shell de la aplicación y las funciones de administración del inventario
- Añadir una página de administración de usuarios que almacena los roles por UID

## Pruebas
- `npm test` *(error: Falta el script: "test")*
- `npm run lint` *(error: 6 errores, 1 advertencia)*
