### PR TITLE
fix: correct AuthContext import paths

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ import Stock from "./pages/Stock";
 import Catalogo from "./pages/Catalogo";
 import Ventas from "./pages/Ventas";
 import UserManagement from "./pages/UserManagement";
-import { useAuth } from "./contexts/AuthContext.jsx";
+import { useAuth } from "./context/AuthContext.jsx";
 import RoleRoute from "./components/RoleRoute.jsx";
 
 function App() {

--- a/src/components/InventarioForm.jsx
+++ b/src/components/InventarioForm.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from "react";
 import { collection, getDocs } from "firebase/firestore";
 import { db } from "../firebase/firebaseConfig";
-import { useAuth } from "../contexts/AuthContext.jsx";
+import { useAuth } from "../context/AuthContext.jsx";
 
 const InventarioForm = ({ onAgregar, productoEscaneado }) => {
   const [producto, setProducto] = useState({

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -1,5 +1,5 @@
 import { Navigate } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext.jsx";
+import { useAuth } from "../context/AuthContext.jsx";
 
 const PrivateRoute = ({ children }) => {
   const { user } = useAuth();

--- a/src/components/RoleRoute.jsx
+++ b/src/components/RoleRoute.jsx
@@ -1,5 +1,5 @@
 import { Navigate } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext.jsx";
+import { useAuth } from "../context/AuthContext.jsx";
 
 const RoleRoute = ({ roles, children }) => {
   const { role } = useAuth();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,16 +5,8 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 import Login from './pages/Login.jsx'
- codex/implement-route-protection-and-role-management
 import PrivateRoute from './components/PrivateRoute.jsx'
-
-import { AuthProvider, useAuth } from './context/AuthContext.jsx'
-
-function PrivateRoute({ children }) {
-  const { user } = useAuth()
-  return user ? children : <Navigate to="/login" />
-}
- main
+import { AuthProvider } from './context/AuthContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/pages/Inventario.jsx
+++ b/src/pages/Inventario.jsx
@@ -15,7 +15,7 @@ import { db } from "../firebase/firebaseConfig";
 import InventarioForm from "../components/InventarioForm";
 import InventarioTable from "../components/InventarioTable";
 import Escaner from "../components/Escaner";
-import { useAuth } from "../contexts/AuthContext.jsx";
+import { useAuth } from "../context/AuthContext.jsx";
 
 const Inventario = () => {
   const [inventario, setInventario] = useState([]);

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -9,7 +9,7 @@ import {
   deleteDoc,
 } from "firebase/firestore";
 import { db } from "../firebase/firebaseConfig";
-import { useAuth } from "../contexts/AuthContext.jsx";
+import { useAuth } from "../context/AuthContext.jsx";
 
 const UserManagement = () => {
   const [users, setUsers] = useState([]);

--- a/src/pages/Ventas.jsx
+++ b/src/pages/Ventas.jsx
@@ -17,7 +17,7 @@ import VentasTable from "../components/VentasTable";
 import EncargosTable from "../components/EncargosTable";
 import Escaner from "../components/Escaner";
 import CardTable from "../components/CardTable"; // Ajusta la ruta si es necesario
-import { useAuth } from "../contexts/AuthContext.jsx";
+import { useAuth } from "../context/AuthContext.jsx";
 
 const Ventas = () => {
   const [ventas, setVentas] = useState([]);


### PR DESCRIPTION
## Summary
- fix all AuthContext imports to use `context` directory
- tidy main entry file to remove duplicate PrivateRoute implementation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c0ad034483218c44922c660b40af