### PR TITLE
feat: show user info and manage permissions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,41 +10,60 @@ import { useAuth } from "./context/AuthContext.jsx";
 import RoleRoute from "./components/RoleRoute.jsx";
 
 function App() {
-  const { role } = useAuth();
+  const { user, role, permissions, logout } = useAuth();
   if (role === null) {
     return <div>Cargando...</div>;
   }
 
   return (
     <div style={{ padding: 20 }}>
-      <h1>🧵 Steven Todo en Uniformes</h1>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <h1>🧵 Steven Todo en Uniformes</h1>
+        {user && (
+          <div>
+            <span style={{ marginRight: 10 }}>
+              {user.displayName || user.email} ({role})
+            </span>
+            <button onClick={logout} style={botonEstilo}>
+              Cerrar sesión
+            </button>
+          </div>
+        )}
+      </div>
 
       <nav style={{ marginBottom: 30 }}>
         <Link to="/" style={botonEstilo}>
           🏠 Inicio
         </Link>
-        {role === "Admin" && (
-          <>
-            <Link to="/inventario" style={botonEstilo}>
-              ➕ Agregar Inventario
-            </Link>
-            <Link to="/stock" style={botonEstilo}>
-              📦 Ver Stock Actual
-            </Link>
-            <Link to="/ventas" style={botonEstilo}>
-              💵 Ventas/Encargos
-            </Link>
-            <Link to="/catalogo" style={botonEstilo}>
-              🛒 Catálogo de Productos
-            </Link>
-            <Link to="/usuarios" style={botonEstilo}>
-              👥 Usuarios
-            </Link>
-          </>
+        {permissions.includes("inventario") && (
+          <Link to="/inventario" style={botonEstilo}>
+            ➕ Agregar Inventario
+          </Link>
         )}
-        {role === "Vendedor" && (
+        {permissions.includes("stock") && (
+          <Link to="/stock" style={botonEstilo}>
+            📦 Ver Stock Actual
+          </Link>
+        )}
+        {permissions.includes("ventas") && (
           <Link to="/ventas" style={botonEstilo}>
             💵 Ventas/Encargos
+          </Link>
+        )}
+        {permissions.includes("catalogo") && (
+          <Link to="/catalogo" style={botonEstilo}>
+            🛒 Catálogo de Productos
+          </Link>
+        )}
+        {permissions.includes("usuarios") && (
+          <Link to="/usuarios" style={botonEstilo}>
+            👥 Usuarios
           </Link>
         )}
       </nav>
@@ -54,7 +73,7 @@ function App() {
         <Route
           path="/inventario"
           element={
-            <RoleRoute roles={["Admin"]}>
+            <RoleRoute requiredPermissions={["inventario"]}>
               <Inventario />
             </RoleRoute>
           }
@@ -62,16 +81,23 @@ function App() {
         <Route
           path="/stock"
           element={
-            <RoleRoute roles={["Admin"]}>
+            <RoleRoute requiredPermissions={["stock"]}>
               <Stock />
             </RoleRoute>
           }
         />
-        <Route path="/ventas" element={<Ventas />} />
+        <Route
+          path="/ventas"
+          element={
+            <RoleRoute requiredPermissions={["ventas"]}>
+              <Ventas />
+            </RoleRoute>
+          }
+        />
         <Route
           path="/catalogo"
           element={
-            <RoleRoute roles={["Admin"]}>
+            <RoleRoute requiredPermissions={["catalogo"]}>
               <Catalogo />
             </RoleRoute>
           }
@@ -79,7 +105,7 @@ function App() {
         <Route
           path="/usuarios"
           element={
-            <RoleRoute roles={["Admin"]}>
+            <RoleRoute requiredPermissions={["usuarios"]}>
               <UserManagement />
             </RoleRoute>
           }

--- a/src/components/RoleRoute.jsx
+++ b/src/components/RoleRoute.jsx
@@ -1,11 +1,15 @@
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext.jsx";
 
-const RoleRoute = ({ roles, children }) => {
-  const { role } = useAuth();
+const RoleRoute = ({ roles, requiredPermissions, children }) => {
+  const { role, permissions } = useAuth();
 
   if (role === null) return null;
-  return roles.includes(role) ? children : <Navigate to="/" replace />;
+  const hasRole = roles ? roles.includes(role) : true;
+  const hasPermission = requiredPermissions
+    ? requiredPermissions.some((p) => permissions.includes(p))
+    : true;
+  return hasRole && hasPermission ? children : <Navigate to="/" replace />;
 };
 
 export default RoleRoute;

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -9,11 +9,20 @@ import {
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import { auth, db, GoogleAuthProvider } from "../firebase/firebaseConfig";
 
+const DEFAULT_PERMISSIONS = {
+  Admin: ["inventario", "stock", "ventas", "catalogo", "usuarios"],
+  Vendedor: ["ventas"],
+  Usuario: [],
+};
+
+const getDefaultPermissions = (userRole) => DEFAULT_PERMISSIONS[userRole] ?? [];
+
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [role, setRole] = useState(null);
+  const [permissions, setPermissions] = useState([]);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
@@ -21,21 +30,23 @@ export const AuthProvider = ({ children }) => {
 
       if (currentUser) {
         try {
-          const token = await currentUser.getIdTokenResult(true);
-          const claimRole = token?.claims?.role;
-
-          if (claimRole) {
-            setRole(claimRole);
-          } else {
-            const snap = await getDoc(doc(db, "users", currentUser.uid));
-            setRole(snap.exists() ? snap.data().role : null);
-          }
+          const snap = await getDoc(doc(db, "users", currentUser.uid));
+          const data = snap.exists() ? snap.data() : {};
+          const userRole = data.role ?? null;
+          const userPermissions =
+            data.permissions && data.permissions.length > 0
+              ? data.permissions
+              : getDefaultPermissions(userRole);
+          setRole(userRole);
+          setPermissions(userPermissions);
         } catch (error) {
-          console.error("Error fetching user role:", error);
+          console.error("Error fetching user data:", error);
           setRole(null);
+          setPermissions([]);
         }
       } else {
         setRole(null);
+        setPermissions([]);
       }
     });
     return () => unsubscribe();
@@ -44,19 +55,26 @@ export const AuthProvider = ({ children }) => {
   const login = (email, password) =>
     signInWithEmailAndPassword(auth, email, password);
 
-const loginWithGoogle = async () => {
-  const provider = new GoogleAuthProvider();
-  const result = await signInWithPopup(auth, provider);
-  const userRef = doc(db, "users", result.user.uid);
-  const snap = await getDoc(userRef);
-  let userRole = "Vendedor";
-  if (!snap.exists() || !snap.data().role) {
-    await setDoc(userRef, { role: userRole }, { merge: true });
-  } else {
-    userRole = snap.data().role;
-  }
-  setRole(userRole);
-};
+  const loginWithGoogle = async () => {
+    const provider = new GoogleAuthProvider();
+    const result = await signInWithPopup(auth, provider);
+    const userRef = doc(db, "users", result.user.uid);
+    const snap = await getDoc(userRef);
+    let userRole = snap.exists() ? snap.data().role || "Vendedor" : "Vendedor";
+    let userPermissions = snap.exists() ? snap.data().permissions : undefined;
+    if (!snap.exists()) {
+      userPermissions = getDefaultPermissions(userRole);
+      await setDoc(
+        userRef,
+        { role: userRole, permissions: userPermissions },
+        { merge: true }
+      );
+    } else if (!userPermissions || userPermissions.length === 0) {
+      userPermissions = getDefaultPermissions(userRole);
+    }
+    setRole(userRole);
+    setPermissions(userPermissions);
+  };
 
 
   const logout = () => signOut(auth);
@@ -66,6 +84,7 @@ const loginWithGoogle = async () => {
       value={{
         user,
         role,
+        permissions,
         login,
         loginWithGoogle,
         logout,

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -11,10 +11,23 @@ import {
 import { db } from "../firebase/firebaseConfig";
 import { useAuth } from "../context/AuthContext.jsx";
 
+const OPTION_LIST = [
+  { key: "inventario", label: "Inventario" },
+  { key: "stock", label: "Stock" },
+  { key: "ventas", label: "Ventas" },
+  { key: "catalogo", label: "Catálogo" },
+  { key: "usuarios", label: "Usuarios" },
+];
+
 const UserManagement = () => {
   const [users, setUsers] = useState([]);
-  const [newUser, setNewUser] = useState({ name: "", role: "Usuario" });
-  const { role } = useAuth();
+  const [newUser, setNewUser] = useState({
+    name: "",
+    email: "",
+    role: "Usuario",
+    permissions: [],
+  });
+  const { permissions } = useAuth();
 
   useEffect(() => {
     const q = collection(db, "users");
@@ -29,19 +42,40 @@ const UserManagement = () => {
     e.preventDefault();
     if (!newUser.name.trim()) return;
     const ref = doc(collection(db, "users"));
-    await setDoc(ref, { name: newUser.name, role: newUser.role });
-    setNewUser({ name: "", role: "Usuario" });
+    await setDoc(ref, {
+      name: newUser.name,
+      email: newUser.email,
+      role: newUser.role,
+      permissions: newUser.permissions,
+    });
+    setNewUser({ name: "", email: "", role: "Usuario", permissions: [] });
   };
 
   const handleRoleChange = async (id, role) => {
     await updateDoc(doc(db, "users", id), { role });
   };
 
+  const handlePermissionChange = async (id, option, current = []) => {
+    const perms = current.includes(option)
+      ? current.filter((p) => p !== option)
+      : [...current, option];
+    await updateDoc(doc(db, "users", id), { permissions: perms });
+  };
+
+  const toggleNewUserPermission = (option) => {
+    setNewUser((prev) => {
+      const perms = prev.permissions.includes(option)
+        ? prev.permissions.filter((p) => p !== option)
+        : [...prev.permissions, option];
+      return { ...prev, permissions: perms };
+    });
+  };
+
   const handleDelete = async (id) => {
     await deleteDoc(doc(db, "users", id));
   };
 
-  if (role !== "Admin") {
+  if (!permissions.includes("usuarios")) {
     return <div style={{ padding: 20 }}>Acceso restringido</div>;
   }
 
@@ -57,6 +91,13 @@ const UserManagement = () => {
           placeholder="Nombre"
           style={{ marginRight: 10, padding: 5 }}
         />
+        <input
+          type="email"
+          value={newUser.email}
+          onChange={(e) => setNewUser({ ...newUser, email: e.target.value })}
+          placeholder="Correo"
+          style={{ marginRight: 10, padding: 5 }}
+        />
         <select
           value={newUser.role}
           onChange={(e) => setNewUser({ ...newUser, role: e.target.value })}
@@ -65,6 +106,18 @@ const UserManagement = () => {
           <option value="Usuario">Usuario</option>
           <option value="Admin">Admin</option>
         </select>
+        <div style={{ margin: "10px 0" }}>
+          {OPTION_LIST.map((opt) => (
+            <label key={opt.key} style={{ marginRight: 10 }}>
+              <input
+                type="checkbox"
+                checked={newUser.permissions.includes(opt.key)}
+                onChange={() => toggleNewUserPermission(opt.key)}
+              />
+              {opt.label}
+            </label>
+          ))}
+        </div>
         <button type="submit" style={{ padding: "5px 10px" }}>
           ➕ Crear Usuario
         </button>
@@ -77,7 +130,13 @@ const UserManagement = () => {
               Nombre
             </th>
             <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>
+              Correo
+            </th>
+            <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>
               Rol
+            </th>
+            <th style={{ borderBottom: "1px solid #ccc", textAlign: "left" }}>
+              Opciones
             </th>
             <th style={{ borderBottom: "1px solid #ccc" }}>Acciones</th>
           </tr>
@@ -86,6 +145,7 @@ const UserManagement = () => {
           {users.map((user) => (
             <tr key={user.id}>
               <td style={{ padding: "8px 0" }}>{user.name}</td>
+              <td style={{ padding: "8px 0" }}>{user.email}</td>
               <td>
                 <select
                   value={user.role}
@@ -95,6 +155,24 @@ const UserManagement = () => {
                   <option value="Usuario">Usuario</option>
                   <option value="Admin">Admin</option>
                 </select>
+              </td>
+              <td>
+                {OPTION_LIST.map((opt) => (
+                  <label key={opt.key} style={{ marginRight: 10 }}>
+                    <input
+                      type="checkbox"
+                      checked={(user.permissions || []).includes(opt.key)}
+                      onChange={() =>
+                        handlePermissionChange(
+                          user.id,
+                          opt.key,
+                          user.permissions || []
+                        )
+                      }
+                    />
+                    {opt.label}
+                  </label>
+                ))}
               </td>
               <td>
                 <button


### PR DESCRIPTION
## Summary
- Show logged user name, role and a logout button in the app header
- Add permission-based navigation and route protection
- Extend user management to edit email, role and available options per user
- Default to full permission set when Admin has none assigned

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893ec39b3988321a67b6bfe2dd0675d