### PR TITLE
feat: modern login page with nickname support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { useAuth } from "./context/AuthContext.jsx";
 import RoleRoute from "./components/RoleRoute.jsx";
 
 function App() {
-  const { user, role, permissions, logout } = useAuth();
+  const { user, role, permissions, logout, nickname } = useAuth();
   if (role === null) {
     return <div>Cargando...</div>;
   }
@@ -28,7 +28,8 @@ function App() {
         {user && (
           <div>
             <span style={{ marginRight: 10 }}>
-              {user.displayName || user.email} ({role})
+              {user.displayName || user.email} ({role}
+              {nickname ? ` - ${nickname}` : ""})
             </span>
             <button onClick={logout} style={botonEstilo}>
               Cerrar sesión

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,63 +1,286 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext.jsx";
+import styles from "./Login.module.css";
 
 const Login = () => {
-  const { login, loginWithGoogle } = useAuth();
+  const { login, loginWithGoogle, register, resetPassword } = useAuth();
   const navigate = useNavigate();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [mode, setMode] = useState("login");
+  const [formData, setFormData] = useState({
+    email: "",
+    password: "",
+    nickname: "",
+  });
+  const [errors, setErrors] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [authError, setAuthError] = useState("");
+  const [message, setMessage] = useState("");
 
-  const handleEmailLogin = async (e) => {
+  const validate = () => {
+    const newErrors = {};
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      newErrors.email = "Correo inválido";
+    }
+    if (mode !== "reset" && formData.password.length < 6) {
+      newErrors.password = "La contraseña debe tener al menos 6 caracteres";
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const switchMode = (newMode) => {
+    setMode(newMode);
+    setFormData({ email: "", password: "", nickname: "" });
+    setErrors({});
+    setAuthError("");
+    setMessage("");
+  };
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
+    setAuthError("");
+    setMessage("");
+    if (!validate()) return;
+    setLoading(true);
     try {
-      await login(email, password);
-      navigate("/");
+      if (mode === "login") {
+        await login(formData.email, formData.password);
+        navigate("/");
+      } else if (mode === "register") {
+        await register(formData.email, formData.password, formData.nickname);
+        navigate("/");
+      } else if (mode === "reset") {
+        await resetPassword(formData.email);
+        setMessage("Se envió un correo para restablecer la contraseña.");
+      }
     } catch (error) {
-      console.error("Error al iniciar sesión:", error);
-      setErrorMessage("No se pudo iniciar sesión. Verifica tus credenciales.");
+      console.error("Error de autenticación:", error);
+      setAuthError("Error de autenticación. Verifica tus datos.");
+    } finally {
+      setLoading(false);
     }
   };
 
-  const handleGoogleLogin = async () => {
+  const handleGoogle = async () => {
+    setAuthError("");
+    setMessage("");
+    setLoading(true);
     try {
       await loginWithGoogle();
       navigate("/");
     } catch (error) {
-      console.error("Error al iniciar sesión con Google:", error);
-      setErrorMessage(
-        "Error al iniciar sesión con Google. Verifica la configuración de Firebase.",
-      );
+      console.error("Error con Google:", error);
+      setAuthError("Error al iniciar sesión con Google.");
+    } finally {
+      setLoading(false);
     }
   };
 
+  const canSubmit = () => {
+    if (mode === "reset") {
+      return formData.email && !errors.email;
+    }
+    return (
+      formData.email &&
+      formData.password &&
+      !errors.email &&
+      !errors.password
+    );
+  };
+
   return (
-    <div style={{ padding: 20 }}>
-      <h2>Iniciar Sesión</h2>
-      <form onSubmit={handleEmailLogin} style={{ marginBottom: 20 }}>
-        <div>
-          <input
-            type="email"
-            placeholder="Correo"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
+    <div className={styles.container}>
+      <div className={styles.card}>
+        <h1 className={styles.title}>
+          {mode === "register"
+            ? "Crear cuenta"
+            : mode === "reset"
+            ? "Recuperar contraseña"
+            : "Iniciar sesión"}
+        </h1>
+        <p className={styles.subtitle}>
+          {mode === "register"
+            ? "Bienvenido, completa los datos para registrarte."
+            : mode === "reset"
+            ? "Ingresa tu correo para restablecer la contraseña."
+            : "Bienvenido de nuevo"}
+        </p>
+
+        <form onSubmit={handleSubmit} className={styles.form} noValidate>
+          <div className={styles.inputGroup}>
+            <label htmlFor="email" className={styles.label}>
+              Correo
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              className={styles.input}
+              value={formData.email}
+              onChange={handleChange}
+              onBlur={validate}
+              required
+            />
+            {errors.email && (
+              <span className={styles.error} role="alert">
+                {errors.email}
+              </span>
+            )}
+          </div>
+
+          {mode !== "reset" && (
+            <div className={styles.inputGroup}>
+              <label htmlFor="password" className={styles.label}>
+                Contraseña
+              </label>
+              <div className={styles.passwordWrapper}>
+                <input
+                  id="password"
+                  name="password"
+                  type={showPassword ? "text" : "password"}
+                  className={styles.input}
+                  value={formData.password}
+                  onChange={handleChange}
+                  onBlur={validate}
+                  required={mode !== "reset"}
+                />
+                <button
+                  type="button"
+                  className={styles.togglePassword}
+                  onClick={() => setShowPassword((s) => !s)}
+                  aria-label={
+                    showPassword ? "Ocultar contraseña" : "Mostrar contraseña"
+                  }
+                >
+                  {showPassword ? "🙈" : "👁️"}
+                </button>
+              </div>
+              {errors.password && (
+                <span className={styles.error} role="alert">
+                  {errors.password}
+                </span>
+              )}
+            </div>
+          )}
+
+          {mode === "register" && (
+            <div className={styles.inputGroup}>
+              <label htmlFor="nickname" className={styles.label}>
+                Apodo (opcional)
+              </label>
+              <input
+                id="nickname"
+                name="nickname"
+                type="text"
+                className={styles.input}
+                value={formData.nickname}
+                onChange={handleChange}
+              />
+            </div>
+          )}
+
+          {authError && (
+            <div className={styles.error} role="alert">
+              {authError}
+            </div>
+          )}
+          {message && (
+            <div className={styles.success} role="status">
+              {message}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className={styles.button}
+            disabled={!canSubmit() || loading}
+            aria-busy={loading}
+          >
+            {mode === "reset" ? "Enviar" : "Continuar"}
+          </button>
+        </form>
+
+        {mode !== "reset" && (
+          <button
+            type="button"
+            className={styles.googleButton}
+            onClick={handleGoogle}
+            disabled={loading}
+            aria-label="Iniciar sesión con Google"
+          >
+            <img
+              src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg"
+              alt=""
+              className={styles.googleIcon}
+            />
+            Continuar con Google
+          </button>
+        )}
+
+        <div className={styles.options}>
+          {mode === "login" && (
+            <>
+              <button
+                type="button"
+                className={styles.linkButton}
+                onClick={() => switchMode("reset")}
+              >
+                ¿Olvidaste tu contraseña?
+              </button>
+              <div className={styles.smallText}>
+                ¿No tienes cuenta?{" "}
+                <button
+                  type="button"
+                  className={styles.linkButton}
+                  onClick={() => switchMode("register")}
+                >
+                  Regístrate
+                </button>
+              </div>
+            </>
+          )}
+          {mode === "register" && (
+            <button
+              type="button"
+              className={styles.linkButton}
+              onClick={() => switchMode("login")}
+            >
+              ¿Ya tienes cuenta? Inicia sesión
+            </button>
+          )}
+          {mode === "reset" && (
+            <button
+              type="button"
+              className={styles.linkButton}
+              onClick={() => switchMode("login")}
+            >
+              Volver al inicio de sesión
+            </button>
+          )}
         </div>
-        <div>
-          <input
-            type="password"
-            placeholder="Contraseña"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-        </div>
-        <button type="submit">Ingresar</button>
-      </form>
-      <button onClick={handleGoogleLogin}>Ingresar con Google</button>
-      {errorMessage && (
-        <p style={{ color: "red", marginTop: 20 }}>{errorMessage}</p>
-      )}
+
+        <footer className={styles.footer}>
+          <a href="#" target="_blank" rel="noopener noreferrer">
+            Términos
+          </a>
+          {" "}·{" "}
+          <a href="#" target="_blank" rel="noopener noreferrer">
+            Política de Privacidad
+          </a>
+        </footer>
+
+        {loading && (
+          <div className={styles.loaderOverlay}>
+            <div className={styles.loader} />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/pages/Login.module.css
+++ b/src/pages/Login.module.css
@@ -1,0 +1,196 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background-color: #f5f5f5;
+  padding: 1rem;
+}
+
+.card {
+  position: relative;
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 400px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.title {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: #555;
+  margin-bottom: 1.5rem;
+}
+
+.form {
+  width: 100%;
+}
+
+.inputGroup {
+  margin-bottom: 1rem;
+}
+
+.label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+}
+
+.input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  transition: border-color 0.2s ease;
+}
+
+.input:focus {
+  border-color: #3b82f6;
+  outline: none;
+  box-shadow: 0 0 0 1px #3b82f6;
+}
+
+.passwordWrapper {
+  position: relative;
+}
+
+.togglePassword {
+  position: absolute;
+  top: 50%;
+  right: 0.75rem;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #555;
+}
+
+.togglePassword:focus {
+  outline: 2px solid #3b82f6;
+}
+
+.error {
+  color: #e53e3e;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.success {
+  color: #16a34a;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  text-align: center;
+}
+
+.button {
+  width: 100%;
+  padding: 0.75rem;
+  border: none;
+  border-radius: 9999px;
+  background-color: #3b82f6;
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.googleButton {
+  width: 100%;
+  margin-top: 0.75rem;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 9999px;
+  background: #fff;
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.googleButton:hover {
+  transform: scale(1.02);
+}
+
+.googleIcon {
+  width: 18px;
+  height: 18px;
+}
+
+.options {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.linkButton {
+  background: none;
+  border: none;
+  color: #3b82f6;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.875rem;
+}
+
+.linkButton:hover {
+  text-decoration: underline;
+}
+
+.smallText {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.footer {
+  margin-top: 1.5rem;
+  font-size: 0.75rem;
+  text-align: center;
+  color: #666;
+}
+
+.footer a {
+  color: #3b82f6;
+  margin: 0 0.25rem;
+}
+
+.loaderOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+}
+
+.loader {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3b82f6;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add nickname, register, and password reset to AuthContext
- replace login page with accessible component using AuthContext and Google login
- style login page with responsive CSS module and show nickname in header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f09915248321a9b0f4ea94a05a2b