### PR TITLE
feat: style sales and orders tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import Inicio from "./pages/Inicio";
 import Inventario from "./pages/Inventario";
 import Stock from "./pages/Stock";
 import Catalogo from "./pages/Catalogo";
-import Ventas from "./pages/Ventas";
+import VentasEncargos from "./pages/VentasEncargos";
 import UserManagement from "./pages/UserManagement";
 import { useAuth } from "./context/AuthContext.jsx";
 import RoleRoute from "./components/RoleRoute.jsx";
@@ -97,7 +97,7 @@ function App() {
           path="/ventas"
           element={
             <RoleRoute requiredPermissions={["ventas"]}>
-              <Ventas />
+              <VentasEncargos />
             </RoleRoute>
           }
         />

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -83,9 +83,16 @@ export const AuthProvider = ({ children }) => {
             setPermissions(userPermissions);
               setName(userName);
           } catch (error) {
-            console.error("Error fetching user data:", error);
+            if (error.code === "permission-denied") {
+              console.warn(
+                "Insufficient permissions to fetch user data. Using defaults.",
+              );
+            } else {
+              console.error("Error fetching user data:", error);
+            }
             setRole(null);
             setPermissions([]);
+            setName(null);
           }
         } else {
           setRole(null);

--- a/src/index.css
+++ b/src/index.css
@@ -210,3 +210,204 @@ input:checked + .slider {
 input:checked + .slider:before {
   transform: translateX(20px);
 }
+
+:root {
+  --blue: #0052cc;
+  --green: #21ba45;
+  --blue-light: rgba(0, 82, 204, 0.05);
+  --radius: 12px;
+  font-family: "Segoe UI", sans-serif;
+}
+
+body {
+  font-family: "Segoe UI", sans-serif;
+  background: #f7f8fa;
+  color: #333;
+}
+
+.sidebar {
+  background: #fff;
+  border-right: 1px solid #e0e0e0;
+}
+.sidebar .menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  font-size: 16px;
+  color: #333;
+  cursor: pointer;
+}
+.sidebar .menu-item:hover {
+  background: var(--blue-light);
+}
+.sidebar .menu-item.active {
+  background: var(--blue);
+  color: #fff;
+}
+.sidebar .menu-item svg {
+  color: var(--blue);
+}
+.sidebar .menu-item.active svg {
+  color: #fff;
+}
+
+.card,
+.sales-card,
+.modal,
+.popout {
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.card-header {
+  padding: 24px;
+  border-bottom: 1px solid #e0e0e0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.card-title {
+  font-size: 20px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+}
+
+.card-title .icon {
+  color: var(--blue);
+  margin-right: 8px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+  padding: 24px;
+}
+
+.form-grid input,
+.form-grid select {
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: var(--radius);
+  font-size: 14px;
+}
+
+.form-grid input:focus,
+.form-grid select:focus {
+  border-color: var(--blue);
+  outline: none;
+}
+
+.btn-primary {
+  background: var(--blue);
+  color: #fff;
+  padding: 12px 20px;
+  border-radius: var(--radius);
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-primary:hover {
+  background: #003f99;
+}
+
+.btn-confirm {
+  background: var(--green);
+}
+
+.btn-confirm:hover {
+  background: #198f2e;
+}
+
+.sales-tab-controls {
+  display: flex;
+  gap: 8px;
+  padding: 16px;
+}
+
+.sales-tab-btn {
+  flex: 1;
+  padding: 10px;
+  background: none;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.2s;
+  color: var(--blue);
+}
+
+.sales-tab-btn:hover {
+  background: var(--blue-light);
+}
+
+.sales-tab-btn.active {
+  background: var(--blue);
+  color: #fff;
+}
+
+.sales-tab-content {
+  display: none;
+  padding: 16px;
+}
+
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 6px;
+}
+thead th {
+  background: var(--blue-light);
+  padding: 10px 12px;
+  font-weight: 600;
+  color: #555;
+  text-align: center;
+}
+tbody tr {
+  background: #fff;
+  border-radius: var(--radius);
+  transition: background 0.2s;
+}
+tbody tr:hover {
+  background: var(--blue-light);
+}
+tbody td {
+  padding: 10px 12px;
+  text-align: center;
+}
+
+.badge-paid {
+  background: var(--green);
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: var(--radius);
+}
+
+.badge-pending {
+  background: #f4c542;
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: var(--radius);
+}
+
+.badge-delivered {
+  background: var(--green);
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: var(--radius);
+}
+
+details summary {
+  cursor: pointer;
+  background: var(--blue);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+}
+details summary:hover {
+  background: #003f99;
+}

--- a/src/pages/VentasEncargos.jsx
+++ b/src/pages/VentasEncargos.jsx
@@ -19,12 +19,13 @@ import Escaner from "../components/Escaner";
 import CardTable from "../components/CardTable"; // Ajusta la ruta si es necesario
 import { useAuth } from "../context/AuthContext.jsx";
 
-const Ventas = () => {
+const VentasEncargos = () => {
   const [ventas, setVentas] = useState([]);
   const [encargos, setEncargos] = useState([]);
   const [mostrarEscaner, setMostrarEscaner] = useState(false);
   const [productoEscaneado, setProductoEscaneado] = useState(null);
   const [tabActiva, setTabActiva] = useState("ventas");
+  const [totalVentas, setTotalVentas] = useState(0);
   const { role } = useAuth();
 
   // Cargar ventas y encargos al iniciar
@@ -50,6 +51,26 @@ const Ventas = () => {
   useEffect(() => {
     cargarDatos();
   }, []);
+
+  useEffect(() => {
+    setTotalVentas(
+      ventas.reduce((sum, v) => sum + v.precio * v.cantidad, 0)
+    );
+  }, [ventas]);
+
+  useEffect(() => {
+    const btns = document.querySelectorAll(".sales-tab-btn");
+    btns.forEach((btn) => {
+      btn.classList.toggle(
+        "active",
+        btn.dataset.salesTab === `${tabActiva}-tab`
+      );
+    });
+    const contents = document.querySelectorAll(".sales-tab-content");
+    contents.forEach((c) => {
+      c.style.display = c.id === `${tabActiva}-tab` ? "block" : "none";
+    });
+  }, [tabActiva]);
 
   // Escanear QR
   const handleQRDetectado = (codigo) => {
@@ -197,75 +218,56 @@ const Ventas = () => {
     }
   };
   // Calcula el total de ventas
-  const totalVentas = ventas.reduce((sum, v) => sum + v.precio * v.cantidad, 0);
   return (
-    <div style={{ padding: 20 }}>
-      <h2>💰 Gestión de Ventas y Encargos</h2>
-
-      <button
-        onClick={() => setMostrarEscaner(!mostrarEscaner)}
-        style={{
-          backgroundColor: "#4CAF50",
-          color: "white",
-          padding: "10px",
-          marginBottom: "20px",
-          borderRadius: "4px",
-          border: "none",
-          cursor: "pointer",
-        }}
-      >
-        {mostrarEscaner ? "❌ Cerrar Escáner" : "📷 Escanear QR"}
-      </button>
+    <div className="sales-card">
+      <header className="card-header">
+        <h2 className="card-title">
+          <span className="icon">💰</span> Gestión de Ventas y Encargos
+        </h2>
+        <button
+          onClick={() => setMostrarEscaner(!mostrarEscaner)}
+          className="btn-primary"
+        >
+          {mostrarEscaner ? "❌ Cerrar Escáner" : "📷 Escanear QR"}
+        </button>
+      </header>
 
       {mostrarEscaner && <Escaner onScan={handleQRDetectado} />}
 
-      <div style={{ marginBottom: "20px", display: "flex", gap: "10px" }}>
+      <div className="sales-tab-controls">
         <button
+          className="sales-tab-btn active"
+          data-sales-tab="ventas-tab"
           onClick={() => setTabActiva("ventas")}
-          style={{
-            padding: "10px 20px",
-            backgroundColor: tabActiva === "ventas" ? "#2196F3" : "#e0e0e0",
-            color: tabActiva === "ventas" ? "white" : "black",
-            border: "none",
-            borderRadius: "4px",
-            cursor: "pointer",
-          }}
         >
           Ventas
         </button>
         <button
+          className="sales-tab-btn"
+          data-sales-tab="encargos-tab"
           onClick={() => setTabActiva("encargos")}
-          style={{
-            padding: "10px 20px",
-            backgroundColor: tabActiva === "encargos" ? "#2196F3" : "#e0e0e0",
-            color: tabActiva === "encargos" ? "white" : "black",
-            border: "none",
-            borderRadius: "4px",
-            cursor: "pointer",
-          }}
         >
           Encargos
         </button>
       </div>
 
-      {tabActiva === "ventas" ? (
-        <>
-          <VentasForm
-            productoEscaneado={productoEscaneado}
-            onAgregar={handleAgregarVenta}
-            onAgregarEncargo={handleAgregarEncargo}
-          />
+      <div className="sales-tab-content" id="ventas-tab">
+        <VentasForm
+          productoEscaneado={productoEscaneado}
+          onAgregar={handleAgregarVenta}
+          onAgregarEncargo={handleAgregarEncargo}
+        />
 
-          <VentasTable
-            ventas={ventas}
-            totalVentas={totalVentas}
-            onActualizarEstado={(id, estado) =>
-              handleActualizarEstado(id, estado, "ventas")
-            }
-            role={role}
-          />
-        </>
-      ) : (
+        <VentasTable
+          ventas={ventas}
+          totalVentas={totalVentas}
+          onActualizarEstado={(id, estado) =>
+            handleActualizarEstado(id, estado, "ventas")
+          }
+          role={role}
+        />
+      </div>
+      <div className="sales-tab-content" id="encargos-tab">
         <EncargosTable
           encargos={encargos}
           onActualizarEstado={(id, estado) =>
@@ -273,9 +275,9 @@ const Ventas = () => {
           }
           role={role}
         />
-      )}
+      </div>
     </div>
   );
 };
 
-export default Ventas;
+export default VentasEncargos;


### PR DESCRIPTION
## Summary
- resolve merge conflicts and restore sales/orders card layout
- add sidebar styling alongside global card and tab styles
- handle permission-denied errors when fetching user data by warning and using defaults

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68953b24334c8321a585d9d823038f6f