### PR TITLE
Handle missing Firestore permissions with default role

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -87,6 +87,10 @@ export const AuthProvider = ({ children }) => {
               console.warn(
                 "Insufficient permissions to fetch user data. Using defaults.",
               );
+              const fallbackRole = "Usuario";
+              setRole(fallbackRole);
+              setPermissions(getDefaultPermissions(fallbackRole));
+              setName(currentUser?.displayName || "");
             } else {
               console.error("Error fetching user data:", error);
             }


### PR DESCRIPTION
## Resumen
- Se establece un rol básico de forma predeterminada cuando Firestore deniega el permiso.
- Se completan los permisos y el nombre predeterminados para mantener la aplicación utilizable.

