### PR TITLE
feat: pivot stock view with tabs

### DIFF
--- a/src/pages/Stock.jsx
+++ b/src/pages/Stock.jsx
@@ -1,13 +1,18 @@
 // 📄 src/pages/Stock.jsx
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo, useRef } from "react";
 import { collection, query, orderBy, onSnapshot } from "firebase/firestore";
 import { db } from "../firebase/firebaseConfig";
-import StockTable from "../components/StockTable";
+import { FaBoxes, FaFilter } from "react-icons/fa";
+
+const TALLAS = [6, 8, 10, 12, 14, 16, "S", "M", "L", "XL", "XXL"];
 
 const Stock = () => {
   const [productos, setProductos] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState("");
+  const [search, setSearch] = useState("");
+  const inputRef = useRef(null);
 
   useEffect(() => {
     const q = query(
@@ -29,10 +34,55 @@ const Stock = () => {
     return () => unsubscribe(); // Limpia el listener al desmontar
   }, []);
 
+  const planteles = useMemo(() => {
+    const uniques = Array.from(new Set(productos.map((p) => p.colegio)));
+    return uniques.sort();
+  }, [productos]);
+
+  useEffect(() => {
+    if (planteles.length && !activeTab) setActiveTab(planteles[0]);
+  }, [planteles, activeTab]);
+
+  const pivot = useMemo(() => {
+    const grouped = {};
+    productos.forEach(({ colegio, prenda, talla, cantidad }) => {
+      if (!grouped[colegio]) grouped[colegio] = {};
+      if (!grouped[colegio][prenda]) grouped[colegio][prenda] = {};
+      grouped[colegio][prenda][talla] =
+        (grouped[colegio][prenda][talla] || 0) + Number(cantidad || 0);
+    });
+    const result = {};
+    Object.keys(grouped).forEach((colegio) => {
+      result[colegio] = Object.keys(grouped[colegio])
+        .map((producto) => {
+          const row = { producto };
+          let total = 0;
+          TALLAS.forEach((t) => {
+            const qty = grouped[colegio][producto][t] || 0;
+            row[t] = qty;
+            total += qty;
+          });
+          row.total = total;
+          return row;
+        })
+        .filter((r) => r.total > 0);
+    });
+    return result;
+  }, [productos]);
+
+  const getBadgeClass = (n) => {
+    if (n === 0) return "badge--zero";
+    if (n <= 4) return "badge--low";
+    if (n <= 8) return "badge--medium";
+    return "badge--high";
+  };
+
+  const handleFilterClick = () => {
+    inputRef.current?.focus();
+  };
+
   return (
     <div style={{ padding: 20 }}>
-      <h2>📦 Inventario Actual (Stock)</h2>
-
       {loading ? (
         <div
           style={{
@@ -46,7 +96,83 @@ const Stock = () => {
           ⏳ Cargando stock...
         </div>
       ) : (
-        <StockTable stock={productos} />
+        <div className="stock-card">
+          <div className="card-header">
+            <FaBoxes color="var(--blue)" />
+            <h2>Inventario Actual (Stock)</h2>
+          </div>
+          <div className="card-controls">
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder="Buscar plantel o producto…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <button onClick={handleFilterClick}>
+              <FaFilter /> Filtrar
+            </button>
+          </div>
+          <div className="tab-controls" role="tablist">
+            {planteles.map((pl) => (
+              <button
+                key={pl}
+                role="tab"
+                aria-selected={activeTab === pl}
+                className={`tab-btn ${activeTab === pl ? "active" : ""}`}
+                onClick={() => setActiveTab(pl)}
+              >
+                {pl}
+              </button>
+            ))}
+          </div>
+          {planteles.map((pl) => {
+            const rows = (pivot[pl] || []).filter((r) =>
+              r.producto.toLowerCase().includes(search.toLowerCase())
+            );
+            return (
+              <div
+                key={pl}
+                role="tabpanel"
+                hidden={activeTab !== pl}
+                className="tab-content"
+              >
+                <div className="table-wrapper">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Producto</th>
+                        {TALLAS.map((t) => (
+                          <th key={t}>{t}</th>
+                        ))}
+                        <th>Total</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map((row) => (
+                        <tr key={row.producto}>
+                          <td>{row.producto}</td>
+                          {TALLAS.map((t) => (
+                            <td key={`${row.producto}-${t}`}>
+                              <span className={`badge ${getBadgeClass(row[t])}`}>
+                                {row[t]}
+                              </span>
+                            </td>
+                          ))}
+                          <td>
+                            <span className={`badge ${getBadgeClass(row.total)}`}>
+                              {row.total}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       )}
     </div>
   );

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -273,3 +273,141 @@ input:checked + .slider:before {
   gap: 8px;
 }
 
+/* Stock page */
+.stock-card {
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  max-width: 1200px;
+  margin: 0 auto;
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.card-controls {
+  display: flex;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.card-controls input {
+  flex: 1;
+  border: 1px solid #d1d1d1;
+  border-radius: var(--radius);
+  padding: 8px 12px;
+}
+
+.card-controls button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--blue);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.card-controls button:hover {
+  background: #003f99;
+}
+
+.tab-controls {
+  display: flex;
+  width: 100%;
+  background: #f9f9f9;
+  border-bottom: 1px solid #e0e0e0;
+  border-radius: var(--radius) var(--radius) 0 0;
+}
+
+.tab-btn {
+  flex: 1;
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.tab-btn:hover {
+  background: var(--blue-light);
+}
+
+.tab-btn.active {
+  background: var(--blue);
+  color: #fff;
+  font-weight: 600;
+}
+
+.tab-content {
+  padding: 16px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.table-wrapper table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table-wrapper th {
+  background: #f4f6fa;
+  color: #555;
+  font-weight: 600;
+  padding: 12px;
+  text-align: center;
+}
+
+.table-wrapper td {
+  padding: 12px;
+  text-align: center;
+}
+
+.table-wrapper th:first-child,
+.table-wrapper td:first-child {
+  text-align: left;
+}
+
+.table-wrapper tbody tr:hover {
+  background: var(--blue-light);
+}
+
+.badge {
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.badge--zero {
+  background: #f0f0f0;
+  color: #888888;
+}
+
+.badge--low {
+  background: #fff5f5;
+  color: #db2828;
+}
+
+.badge--medium {
+  background: #e6f4ff;
+  color: #2185d0;
+}
+
+.badge--high {
+  background: #effff4;
+  color: #21ba45;
+}
+


### PR DESCRIPTION
## Summary
- transform stock data into a pivot table grouped by plantel with tabs and search
- style stock page with card, controls, tabs, and colored quantity badges

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68965fa7dd5c8321ac15d7452984d163