### PR TITLE
feat: force Google account selector

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -131,6 +131,7 @@ export const AuthProvider = ({ children }) => {
   // ---- Login con Google ----
   const loginWithGoogle = async () => {
     const provider = new GoogleAuthProvider();
+    provider.setCustomParameters({ prompt: "select_account" }); // Fuerza selector de cuenta (prompt=select_account)
     const result = await signInWithPopup(auth, provider);
     const userRef = doc(db, "users", result.user.uid);
     const snap = await getDoc(userRef);


### PR DESCRIPTION
## Summary
- ensure Google login always prompts for account selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689778def1e883218abaffd4a9ffc2f4