### PR TITLE
feat(ventas,encargos,clientes-pedidos): Detalle de ventas reutilizand…

### DIFF
--- a/src/components/ClienteComboBox.jsx
+++ b/src/components/ClienteComboBox.jsx
@@ -1,0 +1,461 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  addDoc,
+  serverTimestamp,
+} from "firebase/firestore";
+import { db } from "../firebase/firebaseConfig";
+import ClientModal from "./clients/ClientModal";
+
+const ClienteComboBox = ({
+  selectedCliente,
+  onClienteChange,
+  placeholder = "Buscar cliente...",
+}) => {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [suggestions, setSuggestions] = useState([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  // Form para nuevo cliente
+  const [clientForm, setClientForm] = useState({
+    nombre: "",
+    cedulaNit: "",
+    telefono: "",
+    direccion: "",
+    notas: "",
+  });
+
+  const inputRef = useRef(null);
+  const listRef = useRef(null);
+  const debounceRef = useRef(null);
+
+  // Debounced search
+  const debouncedSearch = useCallback((term) => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      searchClientes(term);
+    }, 250);
+  }, []);
+
+  // Buscar clientes en Firestore
+  const searchClientes = async (searchValue) => {
+    if (!searchValue || searchValue.trim().length < 2) {
+      setSuggestions([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const term = searchValue.toLowerCase().trim();
+      const results = [];
+
+      // Buscar por nombre (prefijo)
+      const nombreQuery = query(
+        collection(db, "clientes"),
+        where("nombreLower", ">=", term),
+        where("nombreLower", "<=", term + "\uf8ff")
+      );
+      const nombreSnap = await getDocs(nombreQuery);
+
+      // Buscar por teléfono
+      let telefonoResults = [];
+      if (/^\d/.test(term)) {
+        // Si empieza con número
+        const telefonoQuery = query(
+          collection(db, "clientes"),
+          where("telefono", ">=", term),
+          where("telefono", "<=", term + "\uf8ff")
+        );
+        const telefonoSnap = await getDocs(telefonoQuery);
+        telefonoResults = telefonoSnap.docs.map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+      }
+
+      // Buscar por documento exacto
+      let documentoResults = [];
+      if (/^\d+$/.test(term)) {
+        // Si es solo números
+        // Buscar en ambos campos para compatibilidad
+        const [documentoQuery1, documentoQuery2] = await Promise.all([
+          getDocs(
+            query(collection(db, "clientes"), where("cedulaNit", "==", term))
+          ),
+          getDocs(
+            query(collection(db, "clientes"), where("documento", "==", term))
+          ),
+        ]);
+
+        const docs1 = documentoQuery1.docs.map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+        const docs2 = documentoQuery2.docs.map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+
+        // Combinar y eliminar duplicados
+        const allDocs = [...docs1, ...docs2];
+        documentoResults = allDocs.reduce((acc, current) => {
+          const existing = acc.find((item) => item.id === current.id);
+          if (!existing) acc.push(current);
+          return acc;
+        }, []);
+      }
+
+      // Combinar y ordenar resultados
+      const nombreResults = nombreSnap.docs.map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+        score: 1,
+      }));
+      const telefonoScored = telefonoResults.map((doc) => ({
+        ...doc,
+        score: 2,
+      }));
+      const documentoScored = documentoResults.map((doc) => ({
+        ...doc,
+        score: 3,
+      }));
+
+      // Eliminar duplicados y ordenar por score
+      const allResults = [
+        ...nombreResults,
+        ...telefonoScored,
+        ...documentoScored,
+      ];
+      const uniqueResults = allResults.reduce((acc, current) => {
+        const existing = acc.find((item) => item.id === current.id);
+        if (!existing || current.score < existing.score) {
+          return acc.filter((item) => item.id !== current.id).concat(current);
+        }
+        return acc;
+      }, []);
+
+      // Ordenar por score y limitar a 8 resultados
+      results.push(
+        ...uniqueResults.sort((a, b) => a.score - b.score).slice(0, 8)
+      );
+
+      setSuggestions(results);
+    } catch (error) {
+      console.error("Error buscando clientes:", error);
+      setSuggestions([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Manejar cambio en input
+  const handleInputChange = (e) => {
+    const value = e.target.value;
+    setSearchTerm(value);
+    setIsOpen(true);
+    setHighlightedIndex(-1);
+
+    if (value.trim()) {
+      debouncedSearch(value);
+    } else {
+      setSuggestions([]);
+      if (selectedCliente) {
+        onClienteChange(null);
+      }
+    }
+  };
+
+  // Seleccionar cliente
+  const selectCliente = (cliente) => {
+    setSearchTerm(cliente.nombre);
+    setIsOpen(false);
+    setSuggestions([]);
+    setHighlightedIndex(-1);
+    onClienteChange({
+      id: cliente.id,
+      nombre: cliente.nombre,
+      telefono: cliente.telefono || "",
+      documento: cliente.cedulaNit || cliente.documento || "",
+    });
+  };
+
+  // Manejar teclado
+  const handleKeyDown = (e) => {
+    if (!isOpen || suggestions.length === 0) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setHighlightedIndex((prev) =>
+          prev < suggestions.length - 1 ? prev + 1 : prev
+        );
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (highlightedIndex >= 0 && suggestions[highlightedIndex]) {
+          selectCliente(suggestions[highlightedIndex]);
+        }
+        break;
+      case "Escape":
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+        break;
+    }
+  };
+
+  // Manejar focus del input
+  const handleInputFocus = (e) => {
+    e.target.style.borderColor = "#0052cc";
+    e.target.style.boxShadow = "0 0 0 3px rgba(0, 82, 204, 0.1)";
+    if (searchTerm) {
+      setIsOpen(true);
+    }
+  };
+
+  // Manejar blur del input
+  const handleInputBlur = (e) => {
+    e.target.style.borderColor = "#d1d5db";
+    e.target.style.boxShadow = "none";
+  };
+
+  // Crear nuevo cliente
+  const handleSaveClient = async () => {
+    if (!clientForm.nombre || !clientForm.telefono) {
+      alert("Por favor complete nombre y teléfono");
+      return;
+    }
+
+    try {
+      const nuevoCliente = {
+        nombre: clientForm.nombre.trim(),
+        nombreLower: clientForm.nombre.trim().toLowerCase(),
+        telefono: clientForm.telefono.trim(),
+        cedulaNit: clientForm.cedulaNit.trim() || null,
+        direccion: clientForm.direccion.trim() || null,
+        notas: clientForm.notas.trim() || null,
+        fechaCreacion: serverTimestamp(),
+        activo: true,
+      };
+
+      const docRef = await addDoc(collection(db, "clientes"), nuevoCliente);
+
+      // Seleccionar el cliente recién creado
+      const clienteCreado = {
+        id: docRef.id,
+        nombre: nuevoCliente.nombre,
+        telefono: nuevoCliente.telefono,
+        documento: nuevoCliente.documento || "",
+      };
+
+      selectCliente(clienteCreado);
+
+      // Resetear formulario y cerrar modal
+      setClientForm({
+        nombre: "",
+        cedulaNit: "",
+        telefono: "",
+        direccion: "",
+        notas: "",
+      });
+      setShowModal(false);
+
+      alert("Cliente creado exitosamente");
+    } catch (error) {
+      console.error("Error creando cliente:", error);
+      alert("Error al crear cliente");
+    }
+  };
+
+  // Efectos
+  useEffect(() => {
+    if (selectedCliente?.nombre && searchTerm !== selectedCliente.nombre) {
+      setSearchTerm(selectedCliente.nombre);
+    }
+  }, [selectedCliente]);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        inputRef.current &&
+        !inputRef.current.contains(event.target) &&
+        listRef.current &&
+        !listRef.current.contains(event.target)
+      ) {
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="cliente-combobox" style={{ position: "relative" }}>
+      <div style={{ display: "flex", gap: "8px", alignItems: "stretch" }}>
+        <div style={{ flex: 1, position: "relative" }}>
+          <input
+            ref={inputRef}
+            type="text"
+            value={searchTerm}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            onFocus={handleInputFocus}
+            onBlur={handleInputBlur}
+            placeholder={placeholder}
+            style={{
+              width: "250px",
+              padding: "8px 12px",
+              border: "1px solid #d1d5db",
+              borderRadius: "12px",
+              fontSize: "14px",
+              outline: "none",
+              transition: "border-color 0.2s, box-shadow 0.2s",
+              marginRight: "5px",
+            }}
+            aria-label="Buscar cliente"
+            aria-expanded={isOpen}
+            aria-autocomplete="list"
+            role="combobox"
+          />
+
+          {loading && (
+            <div
+              style={{
+                position: "absolute",
+                right: "12px",
+                top: "50%",
+                transform: "translateY(-50%)",
+                color: "#6b7280",
+              }}
+            >
+              ⏳
+            </div>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setShowModal(true)}
+          style={{
+            padding: "8px 12px",
+            backgroundColor: "#0052cc",
+            color: "white",
+            border: "none",
+            borderRadius: "12px",
+            cursor: "pointer",
+            fontSize: "13px",
+            fontWeight: "500",
+            whiteSpace: "nowrap",
+            transition: "background-color 0.2s",
+            minWidth: "120px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "6px",
+          }}
+          onMouseOver={(e) => (e.target.style.backgroundColor = "#0040a3")}
+          onMouseOut={(e) => (e.target.style.backgroundColor = "#0052cc")}
+          aria-label="Crear nuevo cliente"
+        >
+          <span style={{ fontSize: "14px" }}>+</span>
+          <span>Nuevo</span>
+        </button>
+      </div>
+
+      {/* Lista de sugerencias */}
+      {isOpen && suggestions.length > 0 && (
+        <div
+          ref={listRef}
+          role="listbox"
+          style={{
+            position: "absolute",
+            top: "calc(100% + 4px)",
+            left: 0,
+            right: 0,
+            backgroundColor: "white",
+            border: "1px solid #d1d5db",
+            borderRadius: "12px",
+            boxShadow: "0 10px 25px rgba(0, 0, 0, 0.1)",
+            zIndex: 1000,
+            maxHeight: "300px",
+            overflowY: "auto",
+          }}
+        >
+          {suggestions.map((cliente, index) => (
+            <div
+              key={cliente.id}
+              role="option"
+              aria-selected={highlightedIndex === index}
+              style={{
+                padding: "12px 16px",
+                cursor: "pointer",
+                borderBottom:
+                  index < suggestions.length - 1 ? "1px solid #f3f4f6" : "none",
+                backgroundColor:
+                  highlightedIndex === index ? "#f8faff" : "white",
+                transition: "background-color 0.1s",
+              }}
+              onClick={() => selectCliente(cliente)}
+              onMouseEnter={() => setHighlightedIndex(index)}
+            >
+              <div
+                style={{
+                  fontWeight: "600",
+                  color: "#1f2937",
+                  marginBottom: "2px",
+                }}
+              >
+                {cliente.nombre}
+                {cliente.telefono && ` — ${cliente.telefono}`}
+                {(cliente.cedulaNit || cliente.documento) &&
+                  ` — ${cliente.cedulaNit || cliente.documento}`}
+              </div>
+              {cliente.createdAt && (
+                <div style={{ fontSize: "12px", color: "#9ca3af" }}>
+                  Creado:{" "}
+                  {cliente.createdAt.toDate?.()?.toLocaleDateString() ||
+                    "Fecha no disponible"}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Modal para nuevo cliente */}
+      <ClientModal
+        open={showModal}
+        editingClient={null}
+        clientForm={clientForm}
+        setClientForm={setClientForm}
+        onClose={() => {
+          setShowModal(false);
+          setClientForm({
+            nombre: "",
+            cedulaNit: "",
+            telefono: "",
+            direccion: "",
+            notas: "",
+          });
+        }}
+        onSave={handleSaveClient}
+      />
+    </div>
+  );
+};
+
+export default ClienteComboBox;

--- a/src/components/FacturaDetalle.jsx
+++ b/src/components/FacturaDetalle.jsx
@@ -1,0 +1,21 @@
+// src/components/FacturaDetalle.jsx
+import React from "react";
+import InvoicePreview from "./invoices/InvoicePreview";
+
+/**
+ * Muestra una "factura bonita" para pedido | venta | encargo,
+ * reutilizando el mismo componente InvoicePreview + plantillas.
+ *
+ * Props:
+ *  - tipo: "pedidos" | "ventas" | "encargos"
+ *  - template: objeto de plantilla (ventas/encargos/pedidos)
+ *  - data: documento a renderizar
+ */
+export default function FacturaDetalle({ tipo = "pedidos", template, data }) {
+  if (!data) return null;
+  return (
+    <div className="factura-detalle">
+      <InvoicePreview template={template} data={data} />
+    </div>
+  );
+}

--- a/src/components/MigracionClientes.jsx
+++ b/src/components/MigracionClientes.jsx
@@ -1,0 +1,38 @@
+// ===== OPCIÓN 1: Script para consola del navegador =====
+// Ve a tu app en el navegador → F12 → Console → pega este código:
+
+(async () => {
+  try {
+    console.log("🔄 Iniciando migración de clientes...");
+
+    // Usar las funciones de Firestore que ya están cargadas en tu app
+    const { collection, getDocs, updateDoc, doc } =
+      window.firebase?.firestore || window.firebase;
+    const db = window.db; // Asumiendo que tienes db disponible globalmente
+
+    const clientesSnap = await getDocs(collection(db, "clientes"));
+    let actualizados = 0;
+
+    for (const clienteDoc of clientesSnap.docs) {
+      const cliente = clienteDoc.data();
+
+      if (!cliente.nombreLower && cliente.nombre) {
+        const nombreLower = cliente.nombre.toLowerCase().trim();
+
+        await updateDoc(doc(db, "clientes", clienteDoc.id), {
+          nombreLower: nombreLower,
+        });
+
+        console.log(`✅ Actualizado: ${cliente.nombre} → ${nombreLower}`);
+        actualizados++;
+      }
+    }
+
+    console.log(
+      `🎉 Migración completada. ${actualizados} clientes actualizados.`
+    );
+  } catch (error) {
+    console.error("❌ Error en la migración:", error);
+    console.log("💡 Prueba con la OPCIÓN 2 (componente React)");
+  }
+})();

--- a/src/components/VentasTable.jsx
+++ b/src/components/VentasTable.jsx
@@ -170,34 +170,38 @@ const VentasTable = ({ ventas, onActualizarEstado, totalVentas, role }) => {
                                   }}
                                 >
                                   Total: $
-                                  {parseInt(v.precio * v.cantidad).toLocaleString(
-                                    "es-CO"
-                                  )}
+                                  {parseInt(
+                                    v.precio * v.cantidad
+                                  ).toLocaleString("es-CO")}
                                 </div>
                                 <div>
                                   <b>Estado:</b>{" "}
                                   <span
-                                    style={{ color: "#1976d2", fontWeight: 600 }}
+                                    style={{
+                                      color: "#1976d2",
+                                      fontWeight: 600,
+                                    }}
                                   >
                                     {v.estado || "venta"}
                                   </span>
-                                  {v.estado === "separado" && role === "Admin" && (
-                                    <button
-                                      onClick={() => marcarComoPagado(v.id)}
-                                      style={{
-                                        marginLeft: "10px",
-                                        padding: "3px 8px",
-                                        backgroundColor: "#4CAF50",
-                                        color: "white",
-                                        border: "none",
-                                        borderRadius: "4px",
-                                        cursor: "pointer",
-                                        fontWeight: 600,
-                                      }}
-                                    >
-                                      Marcar como pagado
-                                    </button>
-                                  )}
+                                  {v.estado === "separado" &&
+                                    role === "Admin" && (
+                                      <button
+                                        onClick={() => marcarComoPagado(v.id)}
+                                        style={{
+                                          marginLeft: "10px",
+                                          padding: "3px 8px",
+                                          backgroundColor: "#4CAF50",
+                                          color: "white",
+                                          border: "none",
+                                          borderRadius: "4px",
+                                          cursor: "pointer",
+                                          fontWeight: 600,
+                                        }}
+                                      >
+                                        Marcar como pagado
+                                      </button>
+                                    )}
                                 </div>
                                 {v.estado === "separado" && (
                                   <>

--- a/src/components/invoices/InvoicePreview.jsx
+++ b/src/components/invoices/InvoicePreview.jsx
@@ -1,6 +1,11 @@
 import React from "react";
 
 export default function InvoicePreview({ template, data }) {
+  // 👇 helpers arriba del render (o en el componente)
+  const pickDisplayNumber = (data) => {
+    // preferimos numeroCorto si existe
+    return data?.numeroCorto ?? data?.numero ?? data?.id ?? "";
+  };
   // Datos fijos de tu empresa
   const COMPANY = {
     name: "Steven Todo en Uniformes",
@@ -8,6 +13,8 @@ export default function InvoicePreview({ template, data }) {
     phonePretty: "317 284 1355",
     phoneWa: "573172841355", // formato internacional para WhatsApp (Colombia: 57)
   };
+  const numero = data.numeroCorto || data.numero || data.id;
+  const items = Array.isArray(data.items) ? data.items : [];
   return (
     <div className="invoice-preview">
       <div
@@ -69,7 +76,8 @@ export default function InvoicePreview({ template, data }) {
         <div className="invoice-details" style={{ textAlign: "right" }}>
           <h2 style={{ margin: 0 }}>{template.headerText || "FACTURA"}</h2>
           <p style={{ margin: "6px 0" }}>
-            <strong>Nº:</strong> {data.numero || data.id}
+            <strong>Nº:</strong>
+            {pickDisplayNumber(data)}
           </p>
           <p style={{ margin: 0 }}>
             <strong>Fecha:</strong>{" "}

--- a/src/pages/VentasEncargos.jsx
+++ b/src/pages/VentasEncargos.jsx
@@ -10,6 +10,7 @@ import {
   serverTimestamp,
   orderBy,
   getDoc,
+  runTransaction,
 } from "firebase/firestore";
 import { db } from "../firebase/firebaseConfig";
 import VentasForm from "../components/VentasForm";
@@ -124,38 +125,121 @@ const VentasEncargos = () => {
     }
   };
 
-  // Registrar encargo
-  // Registrar encargo
-  const handleAgregarEncargo = async (encargo) => {
-    try {
-      if (
-        !encargo.cliente?.nombre ||
-        !encargo.cliente?.telefono ||
-        !encargo.cliente?.formaPago ||
-        !encargo.productos ||
-        encargo.productos.length === 0
-      ) {
-        throw new Error("Faltan datos requeridos para el encargo");
+  // Consecutivo único, con padding, para ENCARGOS
+  async function getNextEncargoNumeroCorto(db) {
+    const ref = doc(db, "parametros", "facturacionEncargos");
+    const { numeroCorto } = await runTransaction(db, async (tx) => {
+      const snap = await tx.get(ref);
+      let siguiente = 1;
+      let longitud = 4;
+      let prefijo = "";
+
+      if (snap.exists()) {
+        const d = snap.data() || {};
+        siguiente = Number(d.siguiente || 1);
+        longitud = Number(d.longitud || 4);
+        prefijo = d.prefijo || "";
       }
 
-      const encargoData = {
-        numeroFactura: `ENC-${Date.now()}`,
-        cliente: encargo.cliente,
-        productos: encargo.productos,
-        total: encargo.total,
-        abono: encargo.abono || 0,
-        saldo: encargo.saldo || 0,
-        estado: "pendiente",
-        fecha: serverTimestamp(),
-        observaciones: "",
+      const numeroCorto = String(siguiente).padStart(longitud, "0");
+      tx.set(
+        ref,
+        {
+          siguiente: siguiente + 1,
+          longitud,
+          prefijo,
+          actualizadoEn: serverTimestamp(),
+        },
+        { merge: true }
+      );
+
+      return { numeroCorto };
+    });
+
+    return numeroCorto;
+  }
+
+  // Registrar encargo
+  const handleAgregarEncargo = async (data) => {
+    try {
+      // 1) Normalizar items: admite data.items o data.productos
+      const srcItems =
+        Array.isArray(data?.items) && data.items.length
+          ? data.items
+          : Array.isArray(data?.productos)
+          ? data.productos
+          : [];
+
+      const items = srcItems.map((it) => {
+        const cant = Number(it.cantidad ?? 0);
+        const unit = Number(it.vrUnitario ?? it.precioUnit ?? it.precio ?? 0);
+        return {
+          producto: it.producto ?? it.prenda ?? "",
+          plantel: it.plantel ?? it.colegio ?? "",
+          talla: it.talla ?? "",
+          cantidad: cant,
+          vrUnitario: unit,
+          vrTotal: Number(
+            it.vrTotal ?? it.total ?? it.totalFila ?? cant * unit
+          ),
+        };
+      });
+
+      if (items.length === 0) {
+        throw new Error("Sin productos en el encargo");
+      }
+
+      // 2) Normalizar cliente
+      const clienteId =
+        data.clienteId ?? data.cliente?.id ?? data.clienteResumen?.id ?? null;
+
+      const clienteResumen =
+        data.clienteResumen ??
+        (data.cliente
+          ? {
+              nombre: data.cliente.nombre || "",
+              telefono: data.cliente.telefono || "",
+              documento: data.cliente.documento || "",
+            }
+          : null);
+
+      if (!clienteId && !clienteResumen?.nombre) {
+        throw new Error("Falta el cliente (id o nombre)");
+      }
+
+      // 3) Totales / estado / método de pago
+      const total =
+        Number(data.total) ||
+        items.reduce((s, i) => s + (Number(i.vrTotal) || 0), 0);
+      const abono = Number(data.abono ?? 0);
+      const saldo = Number(data.saldo ?? total - abono);
+      const metodoPago = data.metodoPago || data.formaPago || "efectivo";
+      const estado = data.estado || "pendiente";
+
+      // ✅ 4) Consecutivo corto para ENCARGOS (4 dígitos)
+      const numeroCorto = await getNextEncargoNumeroCorto(db);
+
+      const payload = {
+        createdAt: data.createdAt || new Date().toISOString(),
+        estado,
+        clienteId: clienteId || null,
+        clienteResumen: clienteResumen || null,
+        items,
+        total,
+        abono,
+        saldo,
+        metodoPago,
+        // nuevo
+        numeroCorto, // "0001", "0042", etc.
+        numeroPrevio: data.numero ?? null, // por si venía numerado antes
       };
 
-      await addDoc(collection(db, "encargos"), encargoData);
-      cargarDatos();
+      await addDoc(collection(db, "encargos"), payload);
+      alert(`Encargo #${numeroCorto} registrado correctamente`);
       return true;
-    } catch (error) {
-      console.error("Error al registrar encargo:", error);
-      alert(`Error al registrar encargo: ${error.message}`);
+    } catch (err) {
+      console.error("Error al registrar encargo:", err);
+      alert(`Error al registrar encargo: ${err.message}`);
       return false;
     }
   };
@@ -200,7 +284,37 @@ const VentasEncargos = () => {
       console.error("Error al actualizar estado:", error);
     }
   };
-  // Calcula el total de ventas
+
+  // Envoltorio: obtiene numeroCorto y llama al onAgregar "de siempre"
+  const guardarVentaConConsecutivo = async (items, onAgregar) => {
+    // 1) consecutivo
+    const r = await runTransaction(db, async (tx) => {
+      const ref = doc(db, "parametros", "facturacionVentas");
+      const snap = await tx.get(ref);
+      const current = snap.exists() ? Number(snap.data().siguiente) || 1 : 1;
+      const next = current + 1;
+      tx.set(
+        ref,
+        {
+          siguiente: next,
+          longitud: 4,
+          actualizadoEn: new Date().toISOString(),
+        },
+        { merge: true }
+      );
+      return current; // el que usará esta venta
+    });
+    const numeroCorto = String(r).padStart(4, "0");
+
+    // 2) añadimos numeroCorto a cada ítem y delegamos en tu "handleAgregarVenta"
+    const conNumero = (Array.isArray(items) ? items : [items]).map((it) => ({
+      ...it,
+      numeroCorto,
+      numeroPrevio: it.numeroFactura || null,
+    }));
+
+    return onAgregar(conNumero);
+  };
   return (
     <div className="sales-card">
       <header className="card-header">
@@ -244,8 +358,13 @@ const VentasEncargos = () => {
       <div id="ventas-tab" role="tabpanel" hidden={tabActiva !== "ventas"}>
         <VentasForm
           productoEscaneado={productoEscaneado}
-          onAgregar={handleAgregarVenta}
-          onAgregarEncargo={handleAgregarEncargo}
+          //onAgregar={handleAgregarVenta}
+
+          onAgregar={
+            (items) => guardarVentaConConsecutivo(items, handleAgregarVenta) // ← ventas (con consecutivo 0001, 0002, …)
+          }
+          // onAgregar={guardarVentaConConsecutivo}
+          onAgregarEncargo={handleAgregarEncargo} // ← encargos
         />
 
         <VentasTable


### PR DESCRIPTION
…o factura, numeración corta de encargos y flujo sin modal si hay cliente

- /clientes-pedidos:
  * Reuso del componente de factura para 💰 Ventas (mismo look&feel de 📦 Pedidos).
  * Agrupación de ventas por numero (numeroCorto | numeroFactura | numero | id) para mostrar una sola factura con sus ítems.
  * Normalización de ítems (producto/plantel/talla/cantidad/vrUnitario/vrTotal) antes de renderizar.
  * Botón “Ver detalle” funcional en Ventas y Pedidos, sin romper el existente.
  * Suscripción a 'ventas' con orderBy(fechaHora desc).

- /ventas:
  * Si el estado es Encargo y ya hay cliente seleccionado en el ComboBox, NO mostrar modal; se registra directo con ese cliente.
  * Si no hay cliente, se mantiene el modal como fallback.
  * Se conserva el flujo de carrito (agregar y luego registrar).

- Numeración corta (4 dígitos) para Encargos:
  * Nuevo helper con runTransaction: parámetros/facturacionEncargos { siguiente, longitud=4, prefijo="" }.
  * Campo 'numeroCorto' en los nuevos documentos de 'encargos'. Se mantiene 'numeroPrevio' si existía.

- Robustez:
  * Normalización de totales (total/abono/saldo) si no venían en el doc.
  * Evitados hooks fuera de componentes (sin use* dentro de handlers planos).

Notas de datos:
- Crear/ajustar doc Firestore: parametros/facturacionEncargos { "prefijo": "", "longitud": 4, "siguiente": 1, "actualizadoEn": serverTimestamp() } (Cambia 'siguiente' si quieres iniciar desde otro número; p.ej. 4030 ⇒ el próximo emitido será "4029" si ya existe 4029.)